### PR TITLE
Enable CodeQL for PHP

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript' ]  # Only JavaScript for portfolio page analysis
+        # Analyze both JavaScript and PHP sources
+        language: [ 'javascript', 'php' ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
## Summary
- update CodeQL analysis matrix to cover both JavaScript and PHP
- tidy up indentation in workflow file

## Testing
- `yamllint .github/workflows/codeql-analysis.yml` *(fails: too many spaces inside brackets)*

------
https://chatgpt.com/codex/tasks/task_e_6846787e21b483209c2c4c31ee759913