### PR TITLE
Use server proxy for LinkedIn testimonials

### DIFF
--- a/inc/linkedinProxy.php
+++ b/inc/linkedinProxy.php
@@ -1,0 +1,36 @@
+<?php
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+
+$token = getenv('LINKEDIN_ACCESS_TOKEN');
+if (!$token) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Access token not configured']);
+    exit;
+}
+
+$url = 'https://api.linkedin.com/v2/recommendations?q=received&start=0&count=5&projection=(elements*(recommendationText,recommender~(firstName,lastName,profilePicture(displayImage~:playableStreams))))';
+
+$ch = curl_init($url);
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    'Authorization: Bearer ' . $token,
+    'X-Restli-Protocol-Version: 2.0.0'
+]);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+$response = curl_exec($ch);
+$error = curl_error($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+if ($error) {
+    http_response_code(500);
+    echo json_encode(['error' => $error]);
+    exit;
+}
+
+http_response_code($code);
+if ($response) {
+    echo $response;
+} else {
+    echo json_encode(['error' => 'No response from LinkedIn']);
+}

--- a/index.html
+++ b/index.html
@@ -426,28 +426,13 @@ cloud solutions (GCP, AWS, Azure, Oracle Cloud)
                         <div class="testimonial-slider__slide swiper-slide">
                             <div id="linkedin-testimonials">Loading testimonials...</div>
                             <script>
-                              const profileApi = 'https://api.linkedin.com/v2/me?projection=(id,profilePicture(displayImage~:playableStreams))'
-                              const recommendationsApi = 'https://api.linkedin.com/v2/recommendations?q=received&start=0&count=5&projection=(elements*(recommendationText,recommender~(firstName,lastName,profilePicture(displayImage~:playableStreams))))'
-                              const accessToken = 'AQVreBjNPXJ1mmevakpZy6jwGW88Vt0OgH1dxj3xhaKRw4AU1xo3i-0qh-K4CUqLmZ7YkQAthxkgpWwe4DBYLVRSgdjmOcNyLO8GMA5QVotcQiJsDOWiXY4GPKCeqPKnUMjwC72o2fSz9k_DMQf_eTXR9ZoZ50fBM68DoXPphq7Wd2NayM1B2-Q8bwMYrprURt4jIe-XF8lRhGcZfOAK_qkdRwzfhahHcJ_hQkv2JZd6QOar8pbOKex-dUzqqohjLQ1cfZTcQM9s0H2P802AOd4Xqhx-svcxc8ynrZd7HH1q0PbFDAH3fXFuwAvpzqcq823L9_SyR3LNhjQUe8Fyn6zmtpJBFQ'
-                              function fetchProfileImage() {
-                                fetch(profileApi, {
-                                  headers: { 'Authorization': `Bearer ${accessToken}` }
-                                })
-                                  .then(res => res.json())
-                                  .then(data => {
-                                    const imgUrl = data.profilePicture["displayImage~"].elements[0].identifiers[0].identifier
-                                    // do something with imgUrl
-                                  })
-                                  .catch(console.error)
-                              }
+                              const recommendationsApi = 'inc/linkedinProxy.php'
 
 
                               async function loadLinkedInTestimonials() {
                                 const container = document.getElementById('linkedin-testimonials')
                                 try {
-                                  const response = await fetch(recommendationsApi, {
-                                    headers: { 'Authorization': `Bearer ${accessToken}` }
-                                  })
+                                  const response = await fetch(recommendationsApi)
                                   if (!response.ok) throw new Error('Network response was not ok')
                                   const data = await response.json()
                                   const testimonials = data.elements || []


### PR DESCRIPTION
## Summary
- add PHP proxy to query LinkedIn API with server-side token
- load testimonials through the proxy to bypass browser CORS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846b00463e88320ab7700039e20297d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a secure proxy endpoint for fetching LinkedIn testimonials, improving privacy and reliability.
- **Refactor**
  - Updated testimonial loading to fetch data from the new proxy instead of directly from LinkedIn, removing the need for client-side access tokens.
- **Bug Fixes**
  - Improved error handling and messaging when testimonials cannot be loaded or are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->