### PR TITLE
Automate LinkedIn testimonials sync

### DIFF
--- a/.github/workflows/update-testimonials.yml
+++ b/.github/workflows/update-testimonials.yml
@@ -1,0 +1,39 @@
+name: Update LinkedIn testimonials
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 3 * * *'
+
+jobs:
+  fetch-testimonials:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Fetch recommendations from LinkedIn
+        env:
+          TOKEN: ${{ secrets.LINKEDIN_ACCESS_TOKEN }}
+        run: |
+          set -e
+          curl -sfL \
+            -H "Authorization: Bearer $TOKEN" \
+            -H 'X-Restli-Protocol-Version: 2.0.0' \
+            "https://api.linkedin.com/v2/recommendations?q=received&start=0&count=5&projection=(elements*(recommendationText,recommender~(firstName,lastName,profilePicture(displayImage~:playableStreams))))" \
+            -o data/testimonials.json
+
+      - name: Commit updated testimonials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add data/testimonials.json
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update testimonials from LinkedIn"
+            git push origin HEAD:${GITHUB_REF}
+          fi

--- a/data/testimonials.json
+++ b/data/testimonials.json
@@ -1,0 +1,26 @@
+[
+  {
+    "img": "images/avatars/user-02.jpg",
+    "name": "Lucas Arruda",
+    "title": "Google Cloud Expert at CI&T",
+    "text": "Cesar is a skilled Java developer who helped us build a Data Analytics platform on top of Google Cloud using Big Data Engineering techniques for a mass media corporation. He certified himself as Google Cloud Architect and had experience with a broad range of technologies throughout the project. He is that type of person you can always count on and who's always bringing new stuff to the team. His involvement with tech communities and conferences is also noticeable."
+  },
+  {
+    "img": "images/avatars/user-03.jpg",
+    "name": "Dillon Roher",
+    "title": "Chief Technical Officer at Apollo Group",
+    "text": "Cesar is a highly intelligent individual with a passion for learning. I truly hope to work with him again in the future!"
+  },
+  {
+    "img": "images/avatars/user-04.jpg",
+    "name": "Ivan de Aguirre",
+    "title": "Project Leader at Eldorado's Research Institute",
+    "text": "Cesar is a passionate, highly motivated and skilled software developer. He enjoys coding, studying and researching. He never let an opportunity of improvement go away, he's always ready to contribute and take on responsibility. He really loves his profession."
+  },
+  {
+    "img": "images/avatars/user-05.jpg",
+    "name": "Victor Di Trani",
+    "title": "Java Software Engineer at RealWorksBV",
+    "text": "Cesar Augusto is an excellent professional for several reasons. In addition to mastering the area in which he works, he knows how to work in groups and deliver results even with challenging deadlines. I say as a friend and co-worker that Cesar is a differential that cannot be missed."
+  }
+]

--- a/index.html
+++ b/index.html
@@ -426,7 +426,7 @@ cloud solutions (GCP, AWS, Azure, Oracle Cloud)
                         <div class="testimonial-slider__slide swiper-slide">
                             <div id="linkedin-testimonials">Loading testimonials...</div>
                             <script>
-                              const recommendationsApi = 'inc/linkedinProxy.php'
+                              const recommendationsApi = 'data/testimonials.json';
 
 
                               async function loadLinkedInTestimonials() {
@@ -435,17 +435,16 @@ cloud solutions (GCP, AWS, Azure, Oracle Cloud)
                                   const response = await fetch(recommendationsApi)
                                   if (!response.ok) throw new Error('Network response was not ok')
                                   const data = await response.json()
-                                  const testimonials = data.elements || []
+                                  const testimonials = Array.isArray(data) ? data : (data.elements || [])
                                   if (testimonials.length === 0) throw new Error('No testimonials found')
                                   container.innerHTML = ''
                                   testimonials.forEach(t => {
-                                    const text = t.recommendationText || ''
-                                    const rec = t.recommender
-                                    const first = rec && rec.firstName ? (rec.firstName.localized ? Object.values(rec.firstName.localized)[0] : rec.firstName) : ''
-                                    const last = rec && rec.lastName ? (rec.lastName.localized ? Object.values(rec.lastName.localized)[0] : rec.lastName) : ''
-                                    const name = `${first} ${last}`.trim()
-                                    let img = ''
-                                    if (rec && rec.profilePicture && rec.profilePicture['displayImage~']) {
+                                    const text = t.text || t.recommendationText || ''
+                                    const name = t.name || ''
+                                    const title = t.title || ''
+                                    let img = t.img || ''
+                                    const rec = t.recommender || t['recommender~']
+                                    if (!img && rec && rec.profilePicture && rec.profilePicture['displayImage~']) {
                                       const ids = rec.profilePicture['displayImage~'].elements
                                       if (ids && ids.length > 0 && ids[0].identifiers && ids[0].identifiers.length > 0) {
                                         img = ids[0].identifiers[0].identifier
@@ -459,6 +458,7 @@ cloud solutions (GCP, AWS, Azure, Oracle Cloud)
                                         <img src="${img}" alt="${name}" class="testimonial-slider__avatar" loading="lazy">
                                         <cite class="testimonial-slider__cite">
                                           <strong>${name}</strong>
+                                          <span>${title}</span>
                                         </cite>
                                       </div>
                                       <p>${text}</p>`


### PR DESCRIPTION
## Summary
- add GitHub Action to pull recommendations from LinkedIn API
- store output in `data/testimonials.json`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847e4a8e9a88320adfc1d69a41e1c61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a set of LinkedIn-style testimonials, now displayed using a local JSON file.
  - Each testimonial includes the recommender's name, title, avatar image, and testimonial text.
- **Chores**
  - Automated daily update of testimonials from LinkedIn via a scheduled workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->