### PR TITLE
fix: remove opacity:0 from Reveal to fix invisible portrait images

### DIFF
--- a/web/components/reveal.tsx
+++ b/web/components/reveal.tsx
@@ -28,8 +28,8 @@ export function Reveal({
   return (
     <motion.div
       className={className}
-      initial={{ opacity: 0, y: 16 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={{ y: 16 }}
+      whileInView={{ y: 0 }}
       viewport={{ once: true, margin: "-80px" }}
       transition={{ duration: 0.5, delay, ease: [0.22, 1, 0.36, 1] }}
     >


### PR DESCRIPTION
## Summary

- `web/components/reveal.tsx`: Remove `opacity: 0` from the `initial` prop and `opacity: 1` from `whileInView` in the `Reveal` scroll-animation wrapper

## Why portrait images appeared broken

The `Reveal` component wrapped the portrait `<img>` in `ExecutiveSummary` with `initial={{ opacity: 0, y: 16 }}`. With `output: "export"` (fully static site), framer-motion bakes this initial state as an **inline style** in the SSR HTML:

```html
<div style="opacity: 0; transform: translateY(16px)">
  `&lt;img src="data:image/jpeg;base64,..." ... /&gt;`
</div>
```

The portrait started completely invisible. It only became visible after:
1. JS loaded and hydrated
2. The user scrolled the element into the viewport (`whileInView` fired)

Any delay in JS load, hydration failure, or scroll position edge case left the portrait permanently invisible — appearing "broken" to the user.

## Fix

Drop `opacity` from the animation entirely. The slide-up `y` transform still provides the reveal effect, but the portrait is **always visible** in the initial HTML — no dependency on JS or scroll timing.

```tsx
// Before
initial={{ opacity: 0, y: 16 }}
whileInView={{ opacity: 1, y: 0 }}

// After
initial={{ y: 16 }}
whileInView={{ y: 0 }}
```

This also applies to all other below-fold sections using `Reveal` (executive summary cards, projects, skills, etc.), making them consistently visible on initial render.

## Test plan

- [ ] Scroll to Executive Summary — portrait image should be visible immediately on scroll into view (not invisible)
- [ ] Verify the slide-up animation still plays on first scroll into view
- [ ] Check reduced-motion path: portrait visible with no animation
- [ ] Confirm no regressions in other sections using `Reveal`

https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_