### PR TITLE
feat: translate contact/stats to all 5 languages and rename handle to CesarNog

### DIFF
--- a/web/components/hero/identity-console.tsx
+++ b/web/components/hero/identity-console.tsx
@@ -113,7 +113,7 @@ export function IdentityConsole() {
               >
                 <span className="status-dot" />
                 <span className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--color-ok)]">
-                  Status: {siteConfig.availability}
+                  Status: {t.contact.availability}
                 </span>
               </m.div>
             )}
@@ -195,7 +195,7 @@ export function IdentityConsole() {
 
       {/* Stats strip */}
       <div className="relative mx-auto mt-16 grid w-full max-w-5xl grid-cols-2 gap-px overflow-hidden rounded-lg border border-[var(--color-hairline)] sm:grid-cols-4">
-        {stats.map((s) => (
+        {stats.map((s, i) => (
           <div key={s.label} className="bg-[var(--color-surface-1)] p-5">
             <p className="font-display text-3xl text-[var(--color-fg)] sm:text-4xl">
               <Counter
@@ -206,7 +206,7 @@ export function IdentityConsole() {
               />
             </p>
             <p className="mt-1 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
-              {s.label}
+              {t.statsLabels[i]}
             </p>
           </div>
         ))}

--- a/web/components/sections/contact-console.tsx
+++ b/web/components/sections/contact-console.tsx
@@ -1,14 +1,19 @@
+"use client";
+
 import { Section } from "@/components/sections/section";
 import { Magnetic } from "@/components/ui/magnetic";
 import { siteConfig } from "@/lib/site-config";
+import { useI18n } from "@/lib/i18n";
 
 export function ContactConsole() {
+  const { t } = useI18n();
+
   const rows = [
-    { k: "Email", v: siteConfig.links.email, href: `mailto:${siteConfig.links.email}` },
-    { k: "LinkedIn", v: "in/cesarnog", href: siteConfig.links.linkedin },
-    { k: "GitHub", v: "@cesarnog", href: siteConfig.links.github },
-    { k: "Location", v: siteConfig.location },
-    { k: "Response time", v: siteConfig.responseTime },
+    { k: t.contact.rowLabels.email, v: siteConfig.links.email, href: `mailto:${siteConfig.links.email}` },
+    { k: t.contact.rowLabels.linkedin, v: "in/CesarNog", href: siteConfig.links.linkedin },
+    { k: t.contact.rowLabels.github, v: "@CesarNog", href: siteConfig.links.github },
+    { k: t.contact.rowLabels.location, v: siteConfig.location },
+    { k: t.contact.rowLabels.responseTime, v: t.contact.responseTime },
   ];
 
   return (
@@ -23,7 +28,7 @@ export function ContactConsole() {
           <div className="flex items-center gap-3">
             <span className="status-dot" />
             <span className="font-mono text-xs uppercase tracking-[0.18em] text-[var(--color-ok)]">
-              {siteConfig.availability}
+              {t.contact.availability}
             </span>
           </div>
           <dl className="mt-6 divide-y divide-[var(--color-hairline)]">
@@ -54,11 +59,10 @@ export function ContactConsole() {
         <div className="panel accent-blue glow flex flex-col justify-between rounded-lg p-6">
           <div>
             <h3 className="font-display text-2xl text-[var(--color-fg)]">
-              Open a briefing
+              {t.contact.briefingTitle}
             </h3>
             <p className="mt-2 text-sm text-[var(--color-fg-muted)]">
-              Cloud architecture, platform engineering, DevOps, FinOps or AI
-              infrastructure — tell me what you're building.
+              {t.contact.briefingDesc}
             </p>
           </div>
           <div className="mt-6 flex flex-col gap-3">
@@ -67,7 +71,7 @@ export function ContactConsole() {
                 href={`mailto:${siteConfig.links.email}?subject=Project%20Briefing`}
                 className="bg-accent inline-flex w-full items-center justify-center rounded-md px-5 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
               >
-                Email Cesar
+                {t.contact.emailCta}
               </a>
             </Magnetic>
             <div className="grid grid-cols-2 gap-3">
@@ -85,7 +89,7 @@ export function ContactConsole() {
                 rel="noreferrer"
                 className="inline-flex items-center justify-center rounded-md border border-[var(--color-hairline-strong)] px-4 py-2.5 text-sm text-[var(--color-fg)] transition-colors hover:border-[var(--color-fg-muted)]"
               >
-                Download CV ↓
+                {t.contact.downloadCv} ↓
               </a>
             </div>
           </div>

--- a/web/lib/i18n.tsx
+++ b/web/lib/i18n.tsx
@@ -44,6 +44,22 @@ type Dict = {
     placeholder: string;
   };
   portraitCaption: string;
+  contact: {
+    briefingTitle: string;
+    briefingDesc: string;
+    emailCta: string;
+    downloadCv: string;
+    availability: string;
+    responseTime: string;
+    rowLabels: {
+      email: string;
+      linkedin: string;
+      github: string;
+      location: string;
+      responseTime: string;
+    };
+  };
+  statsLabels: string[];
 };
 
 const en: Dict = {
@@ -182,6 +198,22 @@ const en: Dict = {
     placeholder: "Ask about Cesar's fit for your role…",
   },
   portraitCaption: "Madrid · Gran Vía",
+  contact: {
+    briefingTitle: "Open a briefing",
+    briefingDesc: "Cloud architecture, platform engineering, DevOps, FinOps or AI infrastructure — tell me what you're building.",
+    emailCta: "Email Cesar",
+    downloadCv: "Download CV",
+    availability: "Available for international projects",
+    responseTime: "Usually replies within 24h",
+    rowLabels: {
+      email: "Email",
+      linkedin: "LinkedIn",
+      github: "GitHub",
+      location: "Location",
+      responseTime: "Response time",
+    },
+  },
+  statsLabels: ["Years in Tech", "Cloud Projects", "Certifications", "Cost Savings Generated"],
 };
 
 const pt: Dict = {
@@ -320,6 +352,22 @@ const pt: Dict = {
     placeholder: "Pergunte sobre a adequação do Cesar ao seu cargo…",
   },
   portraitCaption: "Madrid · Gran Vía",
+  contact: {
+    briefingTitle: "Iniciar um briefing",
+    briefingDesc: "Arquitetura cloud, engenharia de plataformas, DevOps, FinOps ou infraestrutura de IA — diga-me o que está a construir.",
+    emailCta: "Enviar email ao Cesar",
+    downloadCv: "Descarregar CV",
+    availability: "Disponível para projetos internacionais",
+    responseTime: "Responde normalmente em 24h",
+    rowLabels: {
+      email: "Email",
+      linkedin: "LinkedIn",
+      github: "GitHub",
+      location: "Localização",
+      responseTime: "Tempo de resposta",
+    },
+  },
+  statsLabels: ["Anos em Tecnologia", "Projetos Cloud", "Certificações", "Poupança em Custos"],
 };
 
 const es: Dict = {
@@ -458,6 +506,22 @@ const es: Dict = {
     placeholder: "Pregunta por el encaje de Cesar en tu puesto…",
   },
   portraitCaption: "Madrid · Gran Vía",
+  contact: {
+    briefingTitle: "Abrir un briefing",
+    briefingDesc: "Arquitectura cloud, ingeniería de plataformas, DevOps, FinOps o infraestructura de IA — cuéntame qué estás construyendo.",
+    emailCta: "Enviar email a Cesar",
+    downloadCv: "Descargar CV",
+    availability: "Disponible para proyectos internacionales",
+    responseTime: "Suele responder en 24h",
+    rowLabels: {
+      email: "Email",
+      linkedin: "LinkedIn",
+      github: "GitHub",
+      location: "Ubicación",
+      responseTime: "Tiempo de respuesta",
+    },
+  },
+  statsLabels: ["Años en Tecnología", "Proyectos Cloud", "Certificaciones", "Ahorro en Costes"],
 };
 
 const fr: Dict = {
@@ -596,6 +660,22 @@ const fr: Dict = {
     placeholder: "Posez une question sur l'adéquation de Cesar à votre poste…",
   },
   portraitCaption: "Madrid · Gran Vía",
+  contact: {
+    briefingTitle: "Ouvrir un briefing",
+    briefingDesc: "Architecture cloud, ingénierie de plateformes, DevOps, FinOps ou infrastructure IA — dites-moi ce que vous construisez.",
+    emailCta: "Écrire à Cesar",
+    downloadCv: "Télécharger le CV",
+    availability: "Disponible pour des projets internationaux",
+    responseTime: "Répond généralement sous 24h",
+    rowLabels: {
+      email: "Email",
+      linkedin: "LinkedIn",
+      github: "GitHub",
+      location: "Localisation",
+      responseTime: "Délai de réponse",
+    },
+  },
+  statsLabels: ["Ans dans la Tech", "Projets Cloud", "Certifications", "Économies Générées"],
 };
 
 const zh: Dict = {
@@ -734,6 +814,22 @@ const zh: Dict = {
     placeholder: "询问Cesar是否适合您的职位…",
   },
   portraitCaption: "马德里 · 格兰大道",
+  contact: {
+    briefingTitle: "发起项目咨询",
+    briefingDesc: "云架构、平台工程、DevOps、FinOps或AI基础设施——告诉我您正在构建什么。",
+    emailCta: "发邮件给Cesar",
+    downloadCv: "下载简历",
+    availability: "可承接国际项目",
+    responseTime: "通常24小时内回复",
+    rowLabels: {
+      email: "邮箱",
+      linkedin: "LinkedIn",
+      github: "GitHub",
+      location: "地点",
+      responseTime: "回复时间",
+    },
+  },
+  statsLabels: ["技术年限", "云项目", "认证", "节省成本"],
 };
 
 const DICT: Record<Lang, Dict> = { en, pt, es, fr, zh };


### PR DESCRIPTION
## Summary

- Add `contact` and `statsLabels` keys to the i18n Dict with full translations in EN, PT, ES, FR and ZH
- `ContactConsole`: mark as client component, wire all hardcoded English strings (briefing card title/desc, availability, response time, row labels, CTA buttons) through i18n
- `IdentityConsole`: terminal availability status and stats strip labels now pull from i18n instead of hardcoded English in site-config
- Display handles changed from `@cesarnog` / `in/cesarnog` → `@CesarNog` / `in/CesarNog`

## Strings now translated in all 5 languages

| Key | EN | PT | ES | FR | ZH |
|---|---|---|---|---|---|
| `contact.briefingTitle` | Open a briefing | Iniciar um briefing | Abrir un briefing | Ouvrir un briefing | 发起项目咨询 |
| `contact.emailCta` | Email Cesar | Enviar email ao Cesar | Enviar email a Cesar | Écrire à Cesar | 发邮件给Cesar |
| `contact.downloadCv` | Download CV | Descarregar CV | Descargar CV | Télécharger le CV | 下载简历 |
| `contact.availability` | Available for international projects | Disponível para projetos internacionais | Disponible para proyectos internacionales | Disponible pour des projets internationaux | 可承接国际项目 |
| `statsLabels[0]` | Years in Tech | Anos em Tecnologia | Años en Tecnología | Ans dans la Tech | 技术年限 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced internationalization with translated display text for contact status, statistics labels, briefing sections, and call-to-action buttons.
  * Expanded multi-language support across contact and identity sections for English, Portuguese, Spanish, French, and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->