### PR TITLE
Add Google Ads config, Web Vitals reporting, and Search Console verification

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,6 +80,11 @@ export const metadata: Metadata = {
       "x-default": siteConfig.url,
     },
   },
+  // Google Search Console ownership verification (HTML tag method) —
+  // set NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION in Vercel to enable.
+  ...(process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
+    ? { verification: { google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION } }
+    : {}),
 };
 
 export const viewport = { themeColor: "#08090c" };

--- a/components/analytics.tsx
+++ b/components/analytics.tsx
@@ -1,37 +1,47 @@
 import Script from "next/script";
 import { Analytics as VercelAnalytics } from "@vercel/analytics/next";
+import { WebVitalsReporter } from "@/components/web-vitals-reporter";
 
 const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+const GOOGLE_ADS_ID = process.env.NEXT_PUBLIC_GOOGLE_ADS_ID;
 // Falls back to the registered site ID so Hotjar is always active even without an env var
 const HOTJAR_ID = process.env.NEXT_PUBLIC_HOTJAR_ID || "173193";
 
 export function Analytics() {
+  const gtagId = GA_ID || GOOGLE_ADS_ID;
+
   return (
     <>
       {/* Vercel Web Analytics */}
       <VercelAnalytics />
 
-      {/* Google Analytics 4 */}
-      {GA_ID && (
+      {/* Google Analytics 4 + Google Ads (same gtag.js loader, config'd for whichever IDs are set) */}
+      {gtagId && (
         <>
           <Script
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            src={`https://www.googletagmanager.com/gtag/js?id=${gtagId}`}
             strategy="afterInteractive"
           />
           <Script id="ga4-init" strategy="afterInteractive">
             {`
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
+              window.gtag = gtag;
               gtag('js', new Date());
-              gtag('config', '${GA_ID}', {
+              ${GA_ID ? `gtag('config', '${GA_ID}', {
                 page_path: window.location.pathname,
                 anonymize_ip: true,
                 cookie_flags: 'SameSite=None;Secure',
-              });
+              });` : ""}
+              ${GOOGLE_ADS_ID ? `gtag('config', '${GOOGLE_ADS_ID}');` : ""}
+              (window.__cnVitalsQueue || []).splice(0).forEach(function(m){ window.__cnSendVital(m); });
             `}
           </Script>
         </>
       )}
+
+      {/* Core Web Vitals → GA4 performance events */}
+      <WebVitalsReporter />
 
       {/* Hotjar — ID configurable via NEXT_PUBLIC_HOTJAR_ID env var */}
       <Script id="hotjar" strategy="afterInteractive">

--- a/components/web-vitals-reporter.tsx
+++ b/components/web-vitals-reporter.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useReportWebVitals } from "next/web-vitals";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    __cnVitalsQueue?: unknown[];
+    __cnSendVital?: (metric: unknown) => void;
+  }
+}
+
+/**
+ * Reports Core Web Vitals (LCP, CLS, INP, FCP, TTFB) to GA4 as events.
+ * gtag.js loads via next/script "afterInteractive", so early metrics (e.g. LCP
+ * on a bounce visit) can fire before it's ready — those are queued on
+ * window.__cnVitalsQueue and flushed once analytics.tsx's inline script runs.
+ */
+export function WebVitalsReporter() {
+  useReportWebVitals((metric) => {
+    if (typeof window === "undefined") return;
+
+    window.__cnSendVital =
+      window.__cnSendVital ||
+      ((m) => {
+        const metric = m as { name: string; value: number; id: string; rating?: string };
+        if (typeof window.gtag !== "function") {
+          window.__cnVitalsQueue = window.__cnVitalsQueue || [];
+          window.__cnVitalsQueue.push(metric);
+          return;
+        }
+        window.gtag("event", metric.name, {
+          value: Math.round(metric.name === "CLS" ? metric.value * 1000 : metric.value),
+          metric_id: metric.id,
+          metric_value: metric.value,
+          metric_rating: metric.rating,
+          event_category: "Web Vitals",
+          non_interaction: true,
+        });
+      });
+
+    window.__cnSendVital(metric);
+  });
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Extends the site's existing GA4 setup (`components/analytics.tsx`) with the remaining pieces needed for real performance/traffic visibility:

- **Google Ads conversion tracking** — a second `gtag('config', ...)` call sharing the same GA4 loader, gated behind `NEXT_PUBLIC_GOOGLE_ADS_ID`. Only meaningful if you're actually running Ads.
- **Core Web Vitals → GA4** — new `components/web-vitals-reporter.tsx` client component using `next/web-vitals`'s `useReportWebVitals` to send LCP, CLS, INP, FCP, TTFB to GA4 as events. Metrics that fire before gtag has loaded (e.g. LCP on a fast bounce) are queued on `window.__cnVitalsQueue` and flushed once gtag is ready, so nothing is silently dropped.
- **Google Search Console verification** — added via the Next.js Metadata API (`verification.google` in `app/layout.tsx`), gated behind `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`. Omitted entirely from the page when unset (confirmed via build output).

## Setup required before this does anything

All three env vars are optional and the site works identically without them (same graceful-degradation pattern already used for `NEXT_PUBLIC_GA_ID`/`NEXT_PUBLIC_HOTJAR_ID`):

| Env var | Where to get it |
|---|---|
| `NEXT_PUBLIC_GA_ID` | *(likely already set — GA4 wiring pre-existed this PR)* [analytics.google.com](https://analytics.google.com) → Admin → Data Streams → Measurement ID |
| `NEXT_PUBLIC_GOOGLE_ADS_ID` | [ads.google.com](https://ads.google.com) → Tools → Conversions → Conversion ID. Optional. |
| `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` | [search.google.com/search-console](https://search.google.com/search-console) → Settings → Ownership verification → HTML tag → content value |

Set these in Vercel → Project → Settings → Environment Variables.

## Validation

- `npx tsc --noEmit` — passes, 0 errors
- `npm run lint` — 0 errors (4 pre-existing unrelated warnings)
- `npm run build` — succeeds; confirmed in the built output that GA/Ads scripts and the verification meta tag are correctly absent when their env vars are unset (no broken/empty tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_