### PR TITLE
Polish: tighten icon ring, dashed diagram links, fix line-leak at rest

### DIFF
--- a/components/hero/intro-sequence.tsx
+++ b/components/hero/intro-sequence.tsx
@@ -19,12 +19,12 @@ const HeroCanvas = dynamic(
 // final segment. Local SVGs (devicon, MIT) — no runtime CDN dependency.
 // Positions are % of the stage, ringed around the centered 3D cloud.
 const ORBIT_ICONS = [
-  { src: "/icons/aws.svg", name: "AWS", x: 20, y: 34 },
-  { src: "/icons/azure.svg", name: "Azure", x: 78, y: 30 },
-  { src: "/icons/gcp.svg", name: "GCP", x: 14, y: 62 },
-  { src: "/icons/kubernetes.svg", name: "Kubernetes", x: 84, y: 60 },
-  { src: "/icons/terraform.svg", name: "Terraform", x: 32, y: 76 },
-  { src: "/icons/docker.svg", name: "Docker", x: 66, y: 78 },
+  { src: "/icons/aws.svg", name: "AWS", x: 25, y: 31 },
+  { src: "/icons/azure.svg", name: "Azure", x: 75, y: 29 },
+  { src: "/icons/gcp.svg", name: "GCP", x: 19, y: 59 },
+  { src: "/icons/kubernetes.svg", name: "Kubernetes", x: 81, y: 57 },
+  { src: "/icons/terraform.svg", name: "Terraform", x: 34, y: 80 },
+  { src: "/icons/docker.svg", name: "Docker", x: 66, y: 81 },
 ];
 
 /**
@@ -103,7 +103,7 @@ export function IntroSequence() {
         lines.forEach((line, i) => {
           tl.to(
             line,
-            { attr: { "stroke-dashoffset": 0 }, duration: 0.07, ease: "power1.out" },
+            { opacity: 1, duration: 0.06, ease: "power1.out" },
             0.72 + i * 0.035,
           );
         });
@@ -192,12 +192,18 @@ export function IntroSequence() {
               <line
                 key={icon.name}
                 x1={x1} y1={y1} x2={icon.x} y2={icon.y}
-                pathLength={1}
-                strokeDasharray="1"
-                strokeDashoffset="1"
+                // Dashed on purpose: dotted links are the standard visual for
+                // network connections in architecture diagrams. Screen-space
+                // dashes via non-scaling-stroke; visibility gated by an
+                // opacity tween in segment C (a dashoffset "draw" trick does
+                // NOT work here — non-scaling-stroke makes dash patterns
+                // screen-space, ignoring pathLength normalization, which
+                // leaked faint dashed rays over the at-rest identity block).
+                strokeDasharray="5 7"
                 stroke="var(--color-blue)"
-                strokeOpacity="0.3"
+                strokeOpacity="0.45"
                 vectorEffect="non-scaling-stroke"
+                style={{ opacity: 0 }}
               />
             );
           })}
@@ -208,8 +214,14 @@ export function IntroSequence() {
           {ORBIT_ICONS.map((icon) => (
             <div
               key={icon.name}
-              className="absolute flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-lg border border-[var(--color-hairline-strong)] bg-[var(--color-surface-1)]/80 p-2.5 opacity-0"
-              style={{ left: `${icon.x}%`, top: `${icon.y}%` }}
+              className="absolute flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-lg border bg-[var(--color-surface-1)]/80 p-2.5 opacity-0"
+              style={{
+                left: `${icon.x}%`,
+                top: `${icon.y}%`,
+                // Blue-tinted border ties the endpoint chips to the diagram's
+                // connection lines — they read as part of one system.
+                borderColor: "color-mix(in oklab, var(--color-blue) 35%, var(--color-hairline-strong))",
+              }}
             >
               <Image src={icon.src} alt="" width={34} height={34} unoptimized />
             </div>

--- a/components/hero/intro-sequence.tsx
+++ b/components/hero/intro-sequence.tsx
@@ -171,11 +171,12 @@ export function IntroSequence() {
           </svg>
         </div>
 
-        {/* Connection lines — draw from the core out to each icon as it
+        {/* Connection lines — revealed from the core outward as each icon
             arrives, resolving the finale into an architecture diagram.
-            pathLength=1 normalizes every line so a single dashoffset 1→0
-            tween draws it regardless of true length; non-scaling-stroke
-            keeps the 1px weight despite the stretched viewBox. */}
+            Visibility is gated by a per-line opacity tween in segment C (see
+            the quirk note on the <line> elements for why a dashoffset "draw"
+            doesn't work here); non-scaling-stroke keeps the 1px weight
+            despite the stretched viewBox. */}
         <svg
           ref={linesRef}
           className="pointer-events-none absolute inset-0 h-full w-full"

--- a/components/hero/scene3d/CloudCore.tsx
+++ b/components/hero/scene3d/CloudCore.tsx
@@ -130,7 +130,7 @@ export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
       {/* Sparse ambient particle field behind the cloud — atmosphere/depth.
           Client-only canvas (ssr:false), so drei's internal randomness here
           can't cause a hydration mismatch. */}
-      <Sparkles count={70} scale={[9, 5.5, 5]} position={[0, 0.1, -1.2]} size={1.6} speed={0.25} opacity={0.35} color={ACCENT_BLUE} />
+      <Sparkles count={90} scale={[9, 5.5, 5]} position={[0, 0.1, -1.2]} size={1.9} speed={0.25} opacity={0.35} color={ACCENT_BLUE} />
       <pointLight ref={lightRef} position={[0, 0, 0]} color={ACCENT_BLUE} intensity={1.2} distance={8} />
       <Icosahedron ref={coreRef} args={[0.32, 1]} material={coreMat} />
       {BLOCKS.map((_, i) => (

--- a/components/hero/scene3d/materials.tsx
+++ b/components/hero/scene3d/materials.tsx
@@ -15,7 +15,7 @@ export function chassisMaterial() {
   });
 }
 
-export function accentMaterial(emissiveIntensity = 0.9) {
+export function accentMaterial(emissiveIntensity = 1.05) {
   return new THREE.MeshStandardMaterial({
     color: ACCENT_BLUE,
     emissive: ACCENT_BLUE,


### PR DESCRIPTION
## Summary

The "tweak it" pass — final taste refinements on the intro sequence, done after #31 merged (fresh branch from master):

- **Tightened the icon ring** toward the cloud. The six provider chips were drifting into the viewport corners, which made the finale read as scattered elements; they now visibly belong to one system.
- **Dashed connection lines, on purpose.** Dotted links are the standard visual for network connections in architecture diagrams, so the dashes stay (5 7 screen-space pattern) and got brighter (stroke opacity 0.3 → 0.45).
- **Fixed a real visibility leak** found in screenshot review: the previous `pathLength`/`dashoffset` "draw" animation silently never worked — `vector-effect: non-scaling-stroke` makes dash patterns screen-space and ignores `pathLength` normalization — so faint dashed rays were visible over the at-rest identity block the whole time. Line visibility is now gated by a per-line opacity tween in segment C, and the browser quirk is documented inline so the draw trick doesn't get reintroduced.
- **Blue-tinted chip borders** (`color-mix` 35% blue into the hairline) so the endpoint cards read as diagram nodes.
- **Slightly richer glow and atmosphere**: accent strips 0.9 → 1.05 emissive post-boot; starfield 90 particles at size 1.9.

## Validation
- Screenshot-verified at rest (identity block clean — no leaked rays) and at 97% progress (full diagram finale with all six dashed links)
- `tsc`, `lint`, and production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Visual Enhancements**
  - Refined hero-section orbit positioning and connection-line animations for smoother, clearer transitions.
  - Updated orbit endpoint styling for improved visual consistency.
  - Enhanced 3D cloud visuals with more prominent, brighter sparkle effects.
  - Increased the default glow intensity of accent materials for a more vibrant presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->