### PR TITLE
Fix duplicate GA4 gtag load in layout.tsx

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,10 +113,13 @@ client outcomes).
   over the standard portfolio view.
 - `ui/console-greeting.tsx` — a browser-devtools-console Easter egg greeting.
 - `analytics.tsx` + `web-vitals-reporter.tsx` — Vercel Analytics + GA4 + Google
-  Ads (gtag, shared loader, env-var gated: `NEXT_PUBLIC_GA_ID` /
-  `NEXT_PUBLIC_GOOGLE_ADS_ID`) + Hotjar + Core Web Vitals reported to GA4 as
-  events (metrics queued if gtag isn't loaded yet, flushed once ready — see
-  git history for why: GA4 can load after LCP fires on a bounce visit).
+  Ads (gtag, shared loader; `NEXT_PUBLIC_GA_ID` falls back to the registered
+  measurement ID `G-SQR8VVTFEK` so GA4 is always active) + Hotjar + Core Web
+  Vitals reported to GA4 as events (metrics queued if gtag isn't loaded yet,
+  flushed once ready — see git history for why: GA4 can load after LCP fires
+  on a bounce visit). This is the only place gtag.js is loaded — don't add a
+  second raw gtag snippet elsewhere (e.g. `app/layout.tsx`), which would
+  double-fire `gtag('config', ...)` and double-count page views.
 - JSON-LD: `app/layout.tsx` emits a single `@graph` with cross-linked
   `Person` (+ `hasCredential` from `certifications`), `WebSite`, and
   `ProfessionalService` (+ `hasOfferCatalog` from `capabilities`) nodes.
@@ -134,12 +137,13 @@ Real testimonials from named colleagues (CI&T, Apollo Group, Eldorado Research
 Institute, RealWorksBV).
 
 ## Environment variables
-`NEXT_PUBLIC_GA_ID`, `NEXT_PUBLIC_GOOGLE_ADS_ID`, `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`
-are optional and gate cleanly (those features are inert unset). `NEXT_PUBLIC_HOTJAR_ID`
-is **not** a kill switch — `components/analytics.tsx` falls back to the
-registered site ID (`173193`) when it's unset, so Hotjar tracking is always
-active in production regardless of this var; it only lets you point tracking
-at a *different* Hotjar site ID. `GROQ_API_KEY` / `GROK_API_KEY` +
+`NEXT_PUBLIC_GOOGLE_ADS_ID` and `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` are optional
+and gate cleanly (those features are inert unset). Neither `NEXT_PUBLIC_GA_ID` nor
+`NEXT_PUBLIC_HOTJAR_ID` is a kill switch — `components/analytics.tsx` falls back to
+the registered measurement/site IDs (`G-SQR8VVTFEK` / `173193`) when unset, so GA4
+and Hotjar tracking are always active in production regardless of these vars; they
+only let you point tracking at a *different* GA4 property or Hotjar site ID.
+`GROQ_API_KEY` / `GROK_API_KEY` +
 `GROK_MODEL`/`GROQ_MODEL` — chatbot backend, set in Vercel project settings,
 never committed.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Set in Vercel dashboard (Project Settings → Environment variables):
 | `GROK_API_KEY` | AI chatbot — primary (xAI Grok, `xai-...`) |
 | `GROQ_API_KEY` | AI chatbot — fallback (Groq / Llama 3.3) |
 | `RESEND_API_KEY` | Contact form emails (`re_...`) |
-| `NEXT_PUBLIC_GA_ID` | Google Analytics 4 measurement ID (optional) |
+| `NEXT_PUBLIC_GA_ID` | Google Analytics 4 measurement ID (optional — falls back to `G-SQR8VVTFEK`) |
 | `NEXT_PUBLIC_HOTJAR_ID` | Hotjar site ID (default: `173193`) |
 | `GROK_MODEL` | Override xAI model (default: `grok-3-mini`) |
 | `GROQ_MODEL` | Override Groq model (default: `llama-3.3-70b-versatile`) |

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -98,16 +98,6 @@ export default function RootLayout({
         className={`${geist.variable} ${geistMono.variable} ${interTight.variable} ${hanken.variable} tracking-tight-body antialiased`}
         suppressHydrationWarning
       >
-        {/* Google tag (gtag.js) — inserted to satisfy Google verification */}
-        <Script src="https://www.googletagmanager.com/gtag/js?id=G-SQR8VVTFEK" strategy="afterInteractive" />
-        <Script id="gtag-init" strategy="afterInteractive">
-          {`window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);} 
-          gtag('js', new Date());
-
-          gtag('config', 'G-SQR8VVTFEK');`}
-        </Script>
-
         {/* Tab visibility — pauses aurora/canvas when page hidden, saves battery */}
         <Script id="tab-visibility" strategy="afterInteractive">
           {`(function(){var b=document.body;document.addEventListener('visibilitychange',function(){b.classList.toggle('tab-hidden',document.hidden);});})();`}


### PR DESCRIPTION
## Summary
- This PR originally added a GA4 fallback ID to `components/analytics.tsx` — that change has since landed on `master` via #33/#34, so this branch was rebuilt on latest `master` and now contains a different, still-needed fix.
- #34 also pasted a raw `gtag.js` snippet directly into `app/layout.tsx`, on top of the existing `<Analytics />` component (`components/analytics.tsx`) which already loads `gtag.js` and calls `gtag('config', ...)` with better options (`anonymize_ip`, `cookie_flags`, `page_path`). Loading `gtag.js` twice fired `gtag('config', 'G-SQR8VVTFEK')` twice on every page load, double-counting GA4 page views in production.
- Removes the duplicate raw snippet from `app/layout.tsx`; `<Analytics />` remains the single source of truth for gtag loading.
- Updates `CLAUDE.md` and `README.md`, which still described `NEXT_PUBLIC_GA_ID` as optional/inert-when-unset — it now always falls back to `G-SQR8VVTFEK` per the merged change, and CLAUDE.md now notes not to add a second raw gtag snippet elsewhere.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (0 errors, pre-existing unrelated warnings only)
- [x] `npm run build` succeeds
- [x] Verified locally via `npm run start` that the rendered page now calls `gtag('config', ...)` exactly once (previously twice)
