### PR TITLE
Overhaul the 3D hero entrance: domain-specific art, real choreography, resilience

### DIFF
--- a/components/hero/identity-console.tsx
+++ b/components/hero/identity-console.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { m, useMotionTemplate, useMotionValue, useReducedMotion } from "motion/react";
 import { siteConfig, stats, cvByLang } from "@/lib/site-config";
 import { useI18n } from "@/lib/i18n";
@@ -26,18 +26,49 @@ export function IdentityConsole() {
   const mouseY = useMotionValue(-1000);
   const spotlight = useMotionTemplate`radial-gradient(520px at ${mouseX}px ${mouseY}px, color-mix(in oklab, var(--color-blue) 5%, transparent) 0%, transparent 70%)`;
 
-  // Typewriter effect for the hero name — starts after badge entrance delay
+  // Continuous-handoff fix: this section mounts at the same time as the
+  // pinned IntroSequence sitting above it, so a mount-triggered entrance
+  // would finish off-screen before the visitor ever scrolls down to it.
+  // Gate the whole staggered reveal (and the typewriter) on scroll-arrival
+  // instead — the "real hero" now animates to life at the moment the intro's
+  // pin releases and this section actually enters view, same pattern
+  // ui/counter.tsx already uses for its count-up (first-view IntersectionObserver,
+  // disconnect after firing once). Under prefers-reduced-motion IntroSequence
+  // renders nothing, so this section sits at the top of the page from the
+  // first frame and the observer fires immediately — same net effect as before.
+  const sectionRef = useRef<HTMLElement>(null);
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([e]) => {
+        if (e.isIntersecting) {
+          setEntered(true);
+          io.disconnect();
+        }
+      },
+      { threshold: 0 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  // Typewriter effect for the hero name — starts after badge entrance delay,
+  // counted from scroll-arrival (`entered`), not from component mount.
   const LINE1 = siteConfig.firstName; // "César A."
   const LINE2 = "Nogueira.";
   const { displayed: typed1, done: done1 } = useTypewriter(LINE1, {
     charDelay: 62,
     startDelay: DELAYS.name * 1000 + 80,
     skip: !!reduce,
+    start: entered,
   });
   const { displayed: typed2 } = useTypewriter(LINE2, {
     charDelay: 62,
     startDelay: DELAYS.name * 1000 + 80 + LINE1.length * 62 + 200,
     skip: !!reduce,
+    start: entered,
   });
 
   // Live "last active" timestamp for AVAILABLE badge
@@ -52,12 +83,17 @@ export function IdentityConsole() {
     return () => clearInterval(id);
   }, []);
 
+  // `animate` targets the hidden `initial` state until `entered` flips true,
+  // so Motion holds everything at rest off-screen and only actually plays
+  // the stagger once the visitor scrolls this section into view.
   const enter = (delay: number) =>
     reduce
       ? {}
       : {
           initial: { opacity: 0, y: 16, filter: "blur(6px)" },
-          animate: { opacity: 1, y: 0, filter: "blur(0px)" },
+          animate: entered
+            ? { opacity: 1, y: 0, filter: "blur(0px)" }
+            : { opacity: 0, y: 16, filter: "blur(6px)" },
           transition: { duration: DUR.section, delay, ease: EASE.out },
           style: { willChange: "transform" },
         };
@@ -65,6 +101,7 @@ export function IdentityConsole() {
   return (
     <section
       id="top"
+      ref={sectionRef}
       className="relative overflow-hidden"
       onMouseMove={reduce ? undefined : (e) => {
         const rect = e.currentTarget.getBoundingClientRect();
@@ -128,13 +165,13 @@ export function IdentityConsole() {
                 aria-label={`${LINE1} Nogueira.`}
               >
                 <span aria-hidden>
-                  {mounted && !reduce ? typed1 : LINE1}
-                  {mounted && !reduce && !done1 && <span className="cursor-blink" />}
+                  {entered && !reduce ? typed1 : LINE1}
+                  {entered && !reduce && !done1 && <span className="cursor-blink" />}
                 </span>
                 <br />
                 <span aria-hidden>
-                  {mounted && !reduce ? typed2 : LINE2}
-                  {mounted && !reduce && done1 && typed2.length < LINE2.length && <span className="cursor-blink" />}
+                  {entered && !reduce ? typed2 : LINE2}
+                  {entered && !reduce && done1 && typed2.length < LINE2.length && <span className="cursor-blink" />}
                 </span>
               </m.h1>
 
@@ -231,7 +268,7 @@ export function IdentityConsole() {
           aria-hidden
           {...(reduce ? {} : {
             initial: { opacity: 0, scale: 1.03 },
-            animate: { opacity: 1, scale: 1 },
+            animate: entered ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 1.03 },
             transition: { duration: 1.1, delay: DELAYS.photo, ease: EASE.out },
           })}
         >
@@ -248,7 +285,7 @@ export function IdentityConsole() {
         className="absolute bottom-6 left-1/2 -translate-x-1/2 flex items-center justify-center text-[var(--color-fg-subtle)] transition-colors hover:text-[var(--color-fg)]"
         {...(reduce ? {} : {
           initial: { opacity: 0 },
-          animate: { opacity: 1 },
+          animate: entered ? { opacity: 1 } : { opacity: 0 },
           transition: { duration: 0.6, delay: 1.4, ease: EASE.out },
         })}
       >

--- a/components/hero/intro-sequence.tsx
+++ b/components/hero/intro-sequence.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import Image from "next/image";
 import { useReducedMotion } from "motion/react";
@@ -9,6 +9,7 @@ import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { useI18n } from "@/lib/i18n";
 import { siteConfig } from "@/lib/site-config";
 import { ScanReticle } from "@/components/hero/scan-reticle";
+import { WebGLBoundary } from "@/components/hero/scene3d/webgl-boundary";
 
 const HeroCanvas = dynamic(
   () => import("@/components/hero/scene3d/HeroCanvas").then((m) => m.HeroCanvas),
@@ -18,31 +19,71 @@ const HeroCanvas = dynamic(
 // Provider/DevOps icons that orbit in around the assembled cloud in the
 // final segment. Local SVGs (devicon, MIT) — no runtime CDN dependency.
 // Positions are % of the stage, ringed around the centered 3D cloud.
-const ORBIT_ICONS = [
-  { src: "/icons/aws.svg", name: "AWS", x: 25, y: 31 },
-  { src: "/icons/azure.svg", name: "Azure", x: 75, y: 29 },
-  { src: "/icons/gcp.svg", name: "GCP", x: 19, y: 59 },
-  { src: "/icons/kubernetes.svg", name: "Kubernetes", x: 81, y: 57 },
-  { src: "/icons/terraform.svg", name: "Terraform", x: 34, y: 80 },
-  { src: "/icons/docker.svg", name: "Docker", x: 66, y: 81 },
+//
+// `domain` ties each icon into the same Domain-Color Rule the 3D CloudCore
+// assembly now encodes in its own geometry (see scene3d/blocks-data.ts):
+// cloud providers and IaC are architecture (blue), container orchestration
+// is platform/DevOps (cyan). Kept to two domains here deliberately — the
+// provider set itself is infra/IaC tooling, so a FinOps-orange entry would
+// misrepresent what these six logos actually are; FinOps is left for a
+// later stage per this pass's scope (art direction of the 3D geometry only).
+const ORBIT_ICONS: { src: string; name: string; x: number; y: number; domain: "blue" | "cyan" }[] = [
+  { src: "/icons/aws.svg", name: "AWS", x: 25, y: 31, domain: "blue" },
+  { src: "/icons/azure.svg", name: "Azure", x: 75, y: 29, domain: "blue" },
+  { src: "/icons/gcp.svg", name: "GCP", x: 19, y: 59, domain: "blue" },
+  { src: "/icons/kubernetes.svg", name: "Kubernetes", x: 81, y: 57, domain: "cyan" },
+  { src: "/icons/terraform.svg", name: "Terraform", x: 34, y: 80, domain: "blue" },
+  { src: "/icons/docker.svg", name: "Docker", x: 66, y: 81, domain: "cyan" },
 ];
 
 /**
  * Cinematic scroll-scrubbed opening (reference: naramcharan.me, adapted to
- * this brand): a pinned track in three segments —
- *   A (rest → ~28%): scan reticle + identity block (welcome eyebrow, glowing
- *     name, localized role line) + scroll prompt; scattered 3D blocks faint
- *     behind. Identity and reticle drift out as scrolling starts.
- *   B (~15–80%): the canvas ramps to full opacity while the 11-block cloud
- *     core assembles (driven by progressRef inside the R3F frame loop).
- *   C (~75–100%): the core ignites and AWS/Azure/GCP/K8s/Terraform/Docker
- *     icons stagger into an orbit ring around the assembled cloud, then the
- *     pin releases into the unmodified IdentityConsole below.
+ * this brand): a pinned track carrying a five-beat arc —
+ *   A. Identity-first opening (0 → ~0.20): scan reticle + identity block
+ *     (welcome eyebrow, quiet Title-scale name, localized role line) +
+ *     scroll prompt own the first read; scattered 3D blocks sit faint
+ *     behind at rest.
+ *     Identity/reticle/hint drift out as scrolling starts — fully clear
+ *     before the canvas ramps up, so text and 3D never compete for attention.
+ *   B. Infrastructure assembly (~0.20 → ~0.62): the canvas ramps to full
+ *     opacity and the 11-block cloud core docks into place (driven by
+ *     progressRef inside the R3F frame loop — see CloudCore's block delays).
+ *   C. Platform activation (~0.68 → ~0.84): the core ignites — brightening
+ *     visibly *before* any connector line starts drawing, so the finale's
+ *     causality reads correctly (activation invites the diagram, not the
+ *     other way around) — then AWS/Azure/GCP/K8s/Terraform/Docker icons
+ *     stagger into an orbit ring around it.
+ *   D. Stable operating state (~0.84 → 1): the ignite settles to a calm
+ *     glow and idle motion (block bob, cloud drift) tapers to a quieter
+ *     whisper — see the `settle` factors in CloudCore.tsx — rather than
+ *     holding full-amplitude motion indefinitely.
+ *   E. Continuous handoff: the pin releases directly into IdentityConsole,
+ *     whose own entrance is gated on scroll-arrival (not mount), so the
+ *     "real hero" animates to life at the exact moment this scene ends
+ *     instead of arriving already settled off-screen.
+ *
+ * Track height matches CLAUDE.md's documented, scan-time-justified 120vh
+ * baseline exactly (most of a single viewport of real scroll once the
+ * 100dvh pin is subtracted) so this arc doesn't eat into the ~10-second
+ * scan recruiters give the page.
  *
  * All visible copy is localized (t.intro.*, t.hero.*) per this repo's
- * i18n-first rule. The whole sequence duplicates no unique content, so
- * prefers-reduced-motion visitors get null — zero added height, no WebGL
- * fetched — and land directly on the real hero.
+ * i18n-first rule. The identity block's name is deliberately set at
+ * Title scale, not Display — DESIGN.md reserves Display type for "hero
+ * name only, one instance per page," and IdentityConsole's typewriter
+ * is that instance. This block's job is a quick, quiet "here's who" read
+ * at rest; the confirm-beat name reveal belongs to the real hero below,
+ * so the sequence hands off cleanly instead of repeating itself.
+ *
+ * Resilience: `HeroCanvas` is wrapped in `WebGLBoundary` and gated on a
+ * `canvasFailed` flag (set by HeroCanvas's `onContextLost`) so a WebGL
+ * init failure or a lost context degrades to "no 3D scene" instead of
+ * taking the page down — IdentityConsole is a sibling, unaffected either
+ * way. Performance: the Canvas is also gated on `canvasVisible`, an
+ * IntersectionObserver on the track itself, so it unmounts (stopping its
+ * per-frame render loop and freeing GPU resources via CloudCore's existing
+ * disposal effect) once the visitor has scrolled well past it, rather than
+ * rendering forever at `frameloop="always"` for the rest of the session.
  */
 export function IntroSequence() {
   const reduce = useReducedMotion();
@@ -55,7 +96,111 @@ export function IntroSequence() {
   const scrollHintRef = useRef<HTMLDivElement>(null);
   const iconsRef = useRef<HTMLDivElement>(null);
   const linesRef = useRef<SVGSVGElement>(null);
+  const progressBarRef = useRef<HTMLDivElement>(null);
   const progressRef = useRef(0);
+  const [overlayFit, setOverlayFit] = useState(1);
+  const [siteReduced, setSiteReduced] = useState(false);
+  // SSR (and the very first, hydrating client render) must agree, or React
+  // logs a hydration mismatch and the 120vh track visibly collapses/re-
+  // expands. `useReducedMotion()` returns false during SSR but can already
+  // read the real OS media query on the client's first render (framer-
+  // motion evaluates matchMedia synchronously in the hook body, not in an
+  // effect) — so gate the reduced-motion early-return on mount, the same
+  // pattern IdentityConsole/InfraCanvas use elsewhere in this codebase.
+  // Post-mount, an actual reduced-motion visitor still collapses to null
+  // (zero added height, no WebGL fetched) exactly as before; only the very
+  // first paint is now guaranteed to match the server's.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  // WebGL failure/resilience: if Canvas creation throws (caught by
+  // WebGLBoundary below) or the context is lost after creation
+  // (HeroCanvas's onContextLost), stop trying to render the 3D scene for
+  // the rest of this visit. The 2D identity/orbit-icon/connection-line
+  // layer and the scroll-scrubbed handoff into IdentityConsole are
+  // completely independent of the canvas, so they keep working normally.
+  const [canvasFailed, setCanvasFailed] = useState(false);
+  // Perf/resilience: once this 120vh track has scrolled well out of view
+  // (visitor has moved on to Story/ExperienceTimeline/etc.), there is no
+  // reason for the R3F Canvas to keep rendering every frame indefinitely.
+  // Unmounting HeroCanvas (rather than fiddling with `frameloop`) stops the
+  // render loop outright and runs CloudCore's existing material-disposal
+  // cleanup, reclaiming the GPU resources; remounting on scroll-back reads
+  // live from `progressRef` so it snaps back to the correct assembly state
+  // with no extra bookkeeping. Generous rootMargin avoids any pop during
+  // the scroll-through itself, only unmounting once genuinely far away.
+  const [canvasVisible, setCanvasVisible] = useState(true);
+
+  // Mirrors CloudCore's own aspect-aware `fit` (scene3d/CloudCore.tsx) so the
+  // 2D orbit-icon ring and connection lines pull toward center in step with
+  // the 3D cloud on narrow/portrait viewports, instead of staying at full
+  // desktop radius while the assembled cloud behind them shrinks to as
+  // little as 44% scale — which previously left icons/lines floating,
+  // visually disconnected from a much smaller cloud. Floored higher than
+  // CloudCore's 0.44 (at 0.6) because the DOM icon chips are physically
+  // larger than the 3D chassis blocks; matching CloudCore's floor exactly
+  // packs adjacent chips (e.g. Terraform/Docker) close enough to touch at
+  // the narrowest phone widths.
+  useEffect(() => {
+    const el = stageRef.current;
+    if (!el) return;
+    const compute = () => {
+      const { clientWidth: w, clientHeight: h } = el;
+      if (!w || !h) return;
+      setOverlayFit(Math.min(1, Math.max(0.6, w / h / 1.15)));
+    };
+    compute();
+    const ro = new ResizeObserver(compute);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Dual reduced-motion gate: `useReducedMotion()` only reflects the OS-level
+  // media query. This codebase's own MotionToggle sets `data-reduce-motion`
+  // on <html> (components/motion-toggle.tsx), and ui/matrix-rain.tsx already
+  // checks both signals for the same reason — this is the single heaviest
+  // animated component on the site (GSAP-pinned WebGL), so it's the one most
+  // worth respecting the in-app toggle for. A MutationObserver (rather than
+  // a one-time read) picks up a toggle flip that happens mid-visit, before
+  // this section has scrolled into view.
+  useEffect(() => {
+    const check = () =>
+      setSiteReduced(document.documentElement.getAttribute("data-reduce-motion") === "1");
+    check();
+    const mo = new MutationObserver(check);
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-reduce-motion"] });
+    return () => mo.disconnect();
+  }, []);
+
+  const shouldReduce = mounted && (reduce || siteReduced);
+
+  // Perf/resilience: gate the Canvas mount on the track's own viewport
+  // intersection so it stops rendering (and frees its GPU resources) once
+  // the visitor has scrolled well past it, rather than running
+  // `frameloop="always"` forever for the rest of the session.
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => setCanvasVisible(entry.isIntersecting),
+      { rootMargin: "200px 0px 200px 0px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  // Radial position of each orbit icon/connection line, pulled toward center
+  // by `overlayFit` so the finale diagram hugs the shrunk 3D cloud on narrow
+  // viewports rather than floating at full desktop radius around a much
+  // smaller assembly.
+  const scaledIcons = useMemo(
+    () =>
+      ORBIT_ICONS.map((icon) => ({
+        ...icon,
+        cx: 50 + (icon.x - 50) * overlayFit,
+        cy: 52 + (icon.y - 52) * overlayFit,
+      })),
+    [overlayFit],
+  );
 
   // Documented exception to the "Motion for all animation" rule: this scene
   // needs scroll PINNING + scrubbed timeline orchestration, which GSAP
@@ -64,7 +209,7 @@ export function IntroSequence() {
   // useScroll unreliable on a pinned track). GSAP is scoped to this one
   // component; everything else on the site stays on Motion.
   useEffect(() => {
-    if (reduce) return;
+    if (shouldReduce) return;
     gsap.registerPlugin(ScrollTrigger);
 
     const ctx = gsap.context(() => {
@@ -77,6 +222,13 @@ export function IntroSequence() {
           pin: stageRef.current,
           onUpdate: (self) => {
             progressRef.current = self.progress;
+            // Direct ref write (no React state) so the hairline updates
+            // every scroll tick without a re-render, consistent with how
+            // the rest of this scene already avoids React re-renders per
+            // scroll tick (progressRef itself, read inside useFrame).
+            if (progressBarRef.current) {
+              progressBarRef.current.style.transform = `scaleX(${self.progress})`;
+            }
             if (process.env.NODE_ENV !== "production") {
               (window as unknown as { __introProgress?: number }).__introProgress = self.progress;
             }
@@ -87,24 +239,32 @@ export function IntroSequence() {
       tl.to({}, { duration: 1 }, 0);
 
       // Segment A → out: identity drifts up, reticle scales past the camera,
-      // scroll hint drops away. All eased on the scrub.
-      tl.to(identityRef.current, { opacity: 0, y: -48, duration: 0.2, ease: "power2.in" }, 0.06);
-      tl.to(reticleRef.current, { opacity: 0, scale: 1.22, duration: 0.24, ease: "power2.in" }, 0.08);
-      tl.to(scrollHintRef.current, { opacity: 0, y: 24, duration: 0.12, ease: "power1.in" }, 0.04);
+      // scroll hint drops away — all fully clear by ~0.20, before segment B's
+      // canvas ramp begins, so the "identity first" read never has to
+      // compete on-screen with the assembling cloud (previously these
+      // overlapped ~0.10–0.26).
+      tl.to(identityRef.current, { opacity: 0, y: -48, duration: 0.16, ease: "power2.in" }, 0.02);
+      tl.to(reticleRef.current, { opacity: 0, scale: 1.22, duration: 0.18, ease: "power2.in" }, 0.04);
+      tl.to(scrollHintRef.current, { opacity: 0, y: 24, duration: 0.08, ease: "power1.in" }, 0.0);
 
-      // Canvas ramps from faint backdrop to full presence for the assembly.
-      tl.to(canvasWrapRef.current, { opacity: 1, duration: 0.28, ease: "power1.inOut" }, 0.1);
+      // Segment B: canvas ramps from faint backdrop to full presence only
+      // once identity/reticle have cleared, so the handoff from text to 3D
+      // reads as sequential rather than simultaneous.
+      tl.to(canvasWrapRef.current, { opacity: 1, duration: 0.2, ease: "power1.inOut" }, 0.22);
 
-      // Segment C: provider icons orbit in around the assembled cloud, each
-      // preceded by its connection line drawing outward from the core — the
-      // finale resolves into a materializing architecture diagram.
+      // Segment C: the core's own ignite ramp (CloudCore.tsx) starts at
+      // p=0.68. Connector lines/icons are staggered to start at/after that,
+      // not before it (previously lines started at 0.72 while ignite didn't
+      // begin until 0.82 — the diagram appeared to precede activation
+      // instead of following from it). Each icon is still preceded by its
+      // own connection line drawing outward from the already-igniting core.
       if (linesRef.current) {
         const lines = Array.from(linesRef.current.querySelectorAll("line"));
         lines.forEach((line, i) => {
           tl.to(
             line,
-            { opacity: 1, duration: 0.06, ease: "power1.out" },
-            0.72 + i * 0.035,
+            { opacity: 1, duration: 0.05, ease: "power1.out" },
+            0.7 + i * 0.025,
           );
         });
       }
@@ -114,56 +274,84 @@ export function IntroSequence() {
           tl.fromTo(
             chip,
             { opacity: 0, y: 18, scale: 0.85 },
-            { opacity: 1, y: 0, scale: 1, duration: 0.08, ease: "power2.out" },
-            0.74 + i * 0.035,
+            { opacity: 1, y: 0, scale: 1, duration: 0.06, ease: "power2.out" },
+            0.715 + i * 0.025,
           );
         });
       }
     }, trackRef);
 
     return () => ctx.revert();
-  }, [reduce]);
+  }, [shouldReduce]);
 
-  if (reduce) return null;
+  if (shouldReduce) return null;
 
   return (
-    <div ref={trackRef} className="relative h-[220vh]" aria-hidden>
+    <div ref={trackRef} className="relative h-[120vh]" aria-hidden>
       <div ref={stageRef} className="relative h-dvh w-full overflow-hidden bg-[var(--color-surface-0)]">
-        {/* 3D scene — faint at rest so the identity block owns the first read */}
+        {/* 3D scene — faint at rest so the identity block owns the first read.
+            Wrapped in WebGLBoundary (hard requirement: a Canvas init failure
+            must never take the page down) and gated on canvasVisible/
+            canvasFailed — either condition simply renders an empty wrapper
+            div, leaving the 2D layer and the handoff into IdentityConsole
+            completely unaffected. */}
         <div ref={canvasWrapRef} className="absolute inset-0" style={{ opacity: 0.16 }}>
-          <HeroCanvas progressRef={progressRef} />
+          {!canvasFailed && canvasVisible && (
+            <WebGLBoundary>
+              <HeroCanvas progressRef={progressRef} onContextLost={() => setCanvasFailed(true)} />
+            </WebGLBoundary>
+          )}
         </div>
 
-        {/* Scan reticle — upper center */}
+        {/* Scan reticle — upper center. Shrunk on short/landscape viewports
+            (max-height 520px covers ~390-430px-wide phones in landscape)
+            so it clears well before the identity block below it — at rest
+            these two never had more than ~15px clearance in landscape. */}
         <ScanReticle
           ref={reticleRef}
-          className="absolute left-1/2 top-[4vh] h-[min(44vh,380px)] w-[min(44vh,380px)] -translate-x-1/2"
+          className="absolute left-1/2 top-[4vh] h-[min(44vh,380px)] w-[min(44vh,380px)] -translate-x-1/2 [@media(max-height:520px)]:top-[2vh] [@media(max-height:520px)]:h-[min(28vh,200px)] [@media(max-height:520px)]:w-[min(28vh,200px)]"
         />
 
-        {/* Identity block — the Naram-style welcome moment, localized */}
+        {/* Identity block — a quick "here's who" glimpse, not the hero moment.
+            Name sits at Title scale (DESIGN.md), not Display: the Display
+            treatment — the site's one permitted instance — belongs to
+            IdentityConsole's typewriter reveal just below. This block only
+            teases; that one confirms.
+            `top` pulls up on short/landscape viewports (see reticle above)
+            so a longer, wrapped role-line still has headroom before the
+            scroll-hint at the bottom. */}
         <div
           ref={identityRef}
-          className="absolute inset-x-0 top-[52vh] flex flex-col items-center px-6 text-center"
+          className="absolute inset-x-0 top-[52vh] flex flex-col items-center px-6 text-center [@media(max-height:520px)]:top-[34vh]"
         >
           <p className="font-mono text-[13px] tracking-[0.08em] text-[var(--color-blue)]">
             {t.intro.welcome}
           </p>
-          <h2
-            className="mt-2 font-display text-[clamp(2.75rem,6.5vw,5.25rem)] font-bold leading-[0.95] tracking-[-0.025em] text-[var(--color-fg)]"
-            style={{ textShadow: "0 0 32px color-mix(in oklab, var(--color-blue) 45%, transparent)" }}
-          >
+          <p className="mt-2 font-display text-[clamp(1.125rem,2.6vw,1.25rem)] font-medium leading-[1.4] tracking-[-0.01em] text-[var(--color-fg)]">
             {siteConfig.firstName} Nogueira
-          </h2>
-          <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.22em] text-[var(--color-fg-muted)]">
+          </p>
+          {/* max-w + reduced mobile tracking: the PT/ES/FR translations of
+              roleLine + available run ~85-90 characters combined (vs EN's
+              ~76), which wraps to 2-3 lines at 360-430px with the full
+              0.22em tracking and no width cap. Availability is repeated
+              seconds later in IdentityConsole's badge, so it's dropped here
+              below `sm` (same `hidden sm:inline` pattern IdentityConsole
+              already uses for its own secondary timestamp) rather than left
+              to wrap awkwardly on the narrowest phones. */}
+          <p className="mt-4 max-w-[min(90vw,30rem)] font-mono text-[11px] uppercase tracking-[0.14em] text-[var(--color-fg-muted)] sm:tracking-[0.22em]">
             {t.hero.roleLine}
-            <span className="text-[var(--color-ok)]"> · {t.hero.available}</span>
+            <span className="hidden text-[var(--color-ok)] sm:inline"> · {t.hero.available}</span>
           </p>
         </div>
 
-        {/* Scroll prompt — bottom center */}
+        {/* Scroll prompt — bottom center. `env(safe-area-inset-bottom)` keeps
+            it clear of notched-phone home indicators/gesture bars even if
+            the base offset is ever tightened; short/landscape viewports pull
+            it further up so it can't collide with a wrapped identity block
+            above it. */}
         <div
           ref={scrollHintRef}
-          className="absolute inset-x-0 bottom-24 flex flex-col items-center gap-1.5 text-[var(--color-fg-subtle)] sm:bottom-8"
+          className="absolute inset-x-0 bottom-[calc(6rem_+_env(safe-area-inset-bottom))] flex flex-col items-center gap-1.5 text-[var(--color-fg-subtle)] sm:bottom-[calc(2rem_+_env(safe-area-inset-bottom))] [@media(max-height:520px)]:bottom-[calc(1rem_+_env(safe-area-inset-bottom))]"
         >
           <span className="font-mono text-[10px] uppercase tracking-[0.3em]">{t.intro.scroll}</span>
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="animate-float">
@@ -176,23 +364,27 @@ export function IntroSequence() {
             Visibility is gated by a per-line opacity tween in segment C (see
             the quirk note on the <line> elements for why a dashoffset "draw"
             doesn't work here); non-scaling-stroke keeps the 1px weight
-            despite the stretched viewBox. */}
+            despite the stretched viewBox. Endpoints use `scaledIcons`
+            (cx/cy), not the raw ORBIT_ICONS percentages, so the lines shrink
+            toward center with the 3D cloud on narrow viewports instead of
+            staying full desktop length. */}
         <svg
           ref={linesRef}
           className="pointer-events-none absolute inset-0 h-full w-full"
           viewBox="0 0 100 100"
           preserveAspectRatio="none"
         >
-          {ORBIT_ICONS.map((icon) => {
+          {scaledIcons.map((icon) => {
             // Start each line 16% of the way out from center so they don't
             // converge through the core in an asterisk — they emanate from
-            // just outside the ignited sphere instead.
-            const x1 = (50 + (icon.x - 50) * 0.16).toFixed(2);
-            const y1 = (52 + (icon.y - 52) * 0.16).toFixed(2);
+            // just outside the ignited sphere instead. Computed from the
+            // already-scaled cx/cy so the start offset shrinks in step too.
+            const x1 = (50 + (icon.cx - 50) * 0.16).toFixed(2);
+            const y1 = (52 + (icon.cy - 52) * 0.16).toFixed(2);
             return (
               <line
                 key={icon.name}
-                x1={x1} y1={y1} x2={icon.x} y2={icon.y}
+                x1={x1} y1={y1} x2={icon.cx} y2={icon.cy}
                 // Dashed on purpose: dotted links are the standard visual for
                 // network connections in architecture diagrams. Screen-space
                 // dashes via non-scaling-stroke; visibility gated by an
@@ -200,8 +392,11 @@ export function IntroSequence() {
                 // NOT work here — non-scaling-stroke makes dash patterns
                 // screen-space, ignoring pathLength normalization, which
                 // leaked faint dashed rays over the at-rest identity block).
+                // Stroke color matches the icon's domain (see ORBIT_ICONS)
+                // so the diagram itself, not just the 3D core, shows
+                // architecture vs. platform/DevOps as distinct connections.
                 strokeDasharray="5 7"
-                stroke="var(--color-blue)"
+                stroke={icon.domain === "cyan" ? "var(--color-cyan)" : "var(--color-blue)"}
                 strokeOpacity="0.45"
                 vectorEffect="non-scaling-stroke"
                 style={{ opacity: 0 }}
@@ -210,18 +405,23 @@ export function IntroSequence() {
           })}
         </svg>
 
-        {/* Provider/DevOps icon orbit — revealed as the cloud finishes assembling */}
+        {/* Provider/DevOps icon orbit — revealed as the cloud finishes
+            assembling. Positioned from `scaledIcons` (cx/cy) so the ring
+            pulls toward center on narrow viewports along with the 3D cloud
+            and the connection lines above, instead of staying at a fixed
+            desktop radius around a much smaller assembly. */}
         <div ref={iconsRef} className="absolute inset-0">
-          {ORBIT_ICONS.map((icon) => (
+          {scaledIcons.map((icon) => (
             <div
               key={icon.name}
               className="absolute flex -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-lg border bg-[var(--color-surface-1)]/80 p-2.5 opacity-0"
               style={{
-                left: `${icon.x}%`,
-                top: `${icon.y}%`,
-                // Blue-tinted border ties the endpoint chips to the diagram's
-                // connection lines — they read as part of one system.
-                borderColor: "color-mix(in oklab, var(--color-blue) 35%, var(--color-hairline-strong))",
+                left: `${icon.cx}%`,
+                top: `${icon.cy}%`,
+                // Border tints to the icon's domain color, matching its
+                // connection line above — chips read as part of one system,
+                // grouped by discipline rather than uniformly blue.
+                borderColor: `color-mix(in oklab, var(--color-${icon.domain}) 35%, var(--color-hairline-strong))`,
               }}
             >
               <Image src={icon.src} alt={icon.name} width={34} height={34} unoptimized />
@@ -229,8 +429,15 @@ export function IntroSequence() {
           ))}
         </div>
 
-        {/* Scroll-progress hairline along the top edge of the pinned stage */}
-        <div className="absolute inset-x-0 top-0 h-px bg-[var(--color-hairline)]" />
+        {/* Scroll-progress hairline along the top edge of the pinned stage.
+            Width now actually reflects scroll progress (bound via a direct
+            ref write in the ScrollTrigger's onUpdate above — previously this
+            was a static, unbound div despite the comment promising a
+            progress cue, giving zero feedback across a pinned track this
+            long on how much remains before real content appears). */}
+        <div className="absolute inset-x-0 top-0 h-px bg-[var(--color-hairline)]" aria-hidden>
+          <div ref={progressBarRef} className="h-full origin-left bg-[var(--color-blue)]" style={{ transform: "scaleX(0)" }} />
+        </div>
       </div>
     </div>
   );

--- a/components/hero/scene3d/CloudCore.tsx
+++ b/components/hero/scene3d/CloudCore.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import { RoundedBox, Icosahedron, Sparkles } from "@react-three/drei";
+import { RoundedBox } from "@react-three/drei";
 import * as THREE from "three";
-import { BLOCKS, scatterOffset } from "./blocks-data";
-import { chassisMaterial, accentMaterial, coreMaterial, ACCENT_BLUE } from "./materials";
+import { BLOCKS, BOX_ARGS, scatterOffset } from "./blocks-data";
+import { chassisMaterial, accentMaterial, coreMaterial, ACCENT_BLUE, type Domain } from "./materials";
 
 function easeOutCubic(t: number) {
   return 1 - Math.pow(1 - t, 3);
@@ -20,25 +20,37 @@ function smoothstep(edge0: number, edge1: number, x: number) {
   return t * t * (3 - 2 * t);
 }
 
-const SPAN = 0.5; // fraction of assembly progress each block's own animation takes
+// Fraction of assembly progress each block's own dock animation takes. Paired
+// with the retimed `delay` values in blocks-data.ts, every block finishes
+// docking by p≈0.62 — well before the core's ignite ramp starts at p=0.68 —
+// so "infrastructure assembly" reads as a beat that completes before
+// "platform activation" begins, rather than the two overlapping throughout.
+const SPAN = 0.3;
 
 type ProgressRef = React.MutableRefObject<number>;
-type SharedMaterials = { chassis: THREE.Material; accent: THREE.Material };
+type SharedMaterials = { chassis: THREE.Material; accent: Record<Domain, THREE.Material> };
 
 function Block({ index, progressRef, materials }: { index: number; progressRef: ProgressRef; materials: SharedMaterials }) {
   const def = BLOCKS[index];
   const groupRef = useRef<THREE.Group>(null);
   const [sx, sy, sz, srx, sry, srz] = useMemo(() => scatterOffset(index), [index]);
+  const [bw, bh, bd] = BOX_ARGS[def.domain];
 
   const stripRef = useRef<THREE.Mesh>(null);
 
   useFrame((state) => {
     const g = groupRef.current;
     if (!g) return;
-    const t = easeOutCubic(clamp01((progressRef.current - def.delay) / SPAN));
+    const p = progressRef.current;
+    const t = easeOutCubic(clamp01((p - def.delay) / SPAN));
     // Idle "breathing": a tiny per-block bob that grows in as the block
-    // settles — the assembled cloud reads as a live, running system.
-    const bob = Math.sin(state.clock.elapsedTime * 0.9 + index * 1.7) * 0.04 * t;
+    // settles — the assembled cloud reads as a live, running system. Once
+    // the whole scene reaches its stable operating state (p→1) the bob
+    // tapers to a quieter whisper rather than holding full amplitude
+    // forever — a settled system still hums, it doesn't keep visibly
+    // breathing at full strength once handoff is long past.
+    const settle = 1 - smoothstep(0.9, 1, p) * 0.6;
+    const bob = Math.sin(state.clock.elapsedTime * 0.9 + index * 1.7) * 0.04 * t * settle;
     g.position.set(
       THREE.MathUtils.lerp(sx, def.pos[0], t),
       THREE.MathUtils.lerp(sy, def.pos[1], t) + bob,
@@ -59,10 +71,16 @@ function Block({ index, progressRef, materials }: { index: number; progressRef: 
 
   return (
     <group ref={groupRef}>
-      <RoundedBox args={[0.95, 0.6, 0.95]} radius={0.06} smoothness={2} scale={def.scale} material={materials.chassis} />
-      {/* accent strip on the front face — reads as a glowing panel light */}
-      <mesh ref={stripRef} position={[0, 0, 0.48 * def.scale]} material={materials.accent}>
-        <boxGeometry args={[0.62 * def.scale, 0.1 * def.scale, 0.02]} />
+      {/* Per-domain proportions (see BOX_ARGS): architecture stays the
+          original cloud-lobe cube, platform/DevOps modules are wider and
+          flatter (stacked-container read), FinOps modules are narrower and
+          taller (ledger-tile read) — same rounded-corner chassis language
+          throughout, so the kit-of-parts still reads as one system. */}
+      <RoundedBox args={[bw, bh, bd]} radius={0.06} smoothness={2} scale={def.scale} material={materials.chassis} />
+      {/* accent strip on the front face — reads as a glowing panel light,
+          colored by this block's domain (blue/cyan/orange) */}
+      <mesh ref={stripRef} position={[0, 0, (bd / 2 + 0.02) * def.scale]} material={materials.accent[def.domain]}>
+        <boxGeometry args={[bw * 0.65 * def.scale, bh * 0.17 * def.scale, 0.02]} />
       </mesh>
     </group>
   );
@@ -70,12 +88,17 @@ function Block({ index, progressRef, materials }: { index: number; progressRef: 
 
 export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
   const chassis = useMemo(() => chassisMaterial(), []);
-  const accent = useMemo(() => accentMaterial(), []);
+  const accentBlue = useMemo(() => accentMaterial("blue"), []);
+  const accentCyan = useMemo(() => accentMaterial("cyan"), []);
+  const accentOrange = useMemo(() => accentMaterial("orange"), []);
   const coreMat = useMemo(() => coreMaterial(), []);
   const rootRef = useRef<THREE.Group>(null);
   const coreRef = useRef<THREE.Mesh>(null);
   const lightRef = useRef<THREE.PointLight>(null);
-  const materials = useMemo(() => ({ chassis, accent }), [chassis, accent]);
+  const materials = useMemo(
+    () => ({ chassis, accent: { blue: accentBlue, cyan: accentCyan, orange: accentOrange } }),
+    [chassis, accentBlue, accentCyan, accentOrange],
+  );
 
   // Materials created outside R3F's reconciler aren't auto-disposed —
   // free the GPU resources if the scene ever unmounts (e.g. a live
@@ -83,19 +106,25 @@ export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
   useEffect(() => {
     return () => {
       chassis.dispose();
-      accent.dispose();
+      accentBlue.dispose();
+      accentCyan.dispose();
+      accentOrange.dispose();
       coreMat.dispose();
     };
-  }, [chassis, accent, coreMat]);
+  }, [chassis, accentBlue, accentCyan, accentOrange, coreMat]);
 
   useFrame((state) => {
     const p = progressRef.current;
 
     // The whole cloud yaws in as it assembles and settles level at
     // completion — parallax depth on the scrub, plus a whisper of idle
-    // drift so the finished scene never freezes.
+    // drift so the finished scene never freezes. That drift itself tapers
+    // (not to zero) once the scene reaches its stable operating state, so
+    // the "settled system" doesn't keep drifting at the same amplitude it
+    // used while still assembling.
+    const idleSettle = 1 - smoothstep(0.9, 1, p) * 0.55;
     if (rootRef.current) {
-      const idle = Math.sin(state.clock.elapsedTime * 0.18) * 0.02;
+      const idle = Math.sin(state.clock.elapsedTime * 0.18) * 0.02 * idleSettle;
       rootRef.current.rotation.y = THREE.MathUtils.lerp(-0.38, 0.0, easeOutCubic(clamp01(p * 1.15))) + idle;
       rootRef.current.rotation.x = THREE.MathUtils.lerp(0.07, 0.0, clamp01(p * 1.3));
       // Aspect-aware fit: the framing is tuned for wide viewports; on
@@ -113,8 +142,15 @@ export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
     state.camera.position.y = 0.35 - clamp01(p) * 0.15;
     state.camera.lookAt(0, 0.05, 0);
 
-    const ignite = smoothstep(0.82, 0.96, p);
-    const calm = 1 - smoothstep(0.96, 1, p) * 0.35;
+    // Platform activation: ignite starts only after assembly has finished
+    // (p≈0.62, see SPAN/blocks-data.ts), and finishes with room to spare
+    // before the finale's connector lines/icons stop arriving (~p=0.84–0.90)
+    // — so the causal read is "the core lights up, then the diagram grows
+    // out of it," not the two happening at once. Stable operating state:
+    // the glow calms down over the last stretch rather than staying at
+    // peak brightness indefinitely.
+    const ignite = smoothstep(0.68, 0.84, p);
+    const calm = 1 - smoothstep(0.88, 1, p) * 0.4;
     const intensity = (0.6 + ignite * 3) * calm;
     if (coreRef.current) {
       coreRef.current.scale.setScalar(0.85 + ignite * 0.25);
@@ -127,12 +163,14 @@ export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
 
   return (
     <group ref={rootRef}>
-      {/* Sparse ambient particle field behind the cloud — atmosphere/depth.
-          Client-only canvas (ssr:false), so drei's internal randomness here
-          can't cause a hydration mismatch. */}
-      <Sparkles count={90} scale={[9, 5.5, 5]} position={[0, 0.1, -1.2]} size={1.9} speed={0.25} opacity={0.35} color={ACCENT_BLUE} />
       <pointLight ref={lightRef} position={[0, 0, 0]} color={ACCENT_BLUE} intensity={1.2} distance={8} />
-      <Icosahedron ref={coreRef} args={[0.32, 1]} material={coreMat} />
+      {/* The control-plane hub: a small rounded module at the center, same
+          chassis language (RoundedBox, matching corner radius) as the
+          modules docking around it, rather than a faceted crystal — it
+          reads as "the cloud's hub", not an unrelated sci-fi power gem. It
+          stays architecture-blue: the dominant, central discipline the
+          platform and FinOps modules assemble around. */}
+      <RoundedBox ref={coreRef} args={[0.46, 0.46, 0.46]} radius={0.14} smoothness={3} material={coreMat} />
       {BLOCKS.map((_, i) => (
         <Block key={i} index={i} progressRef={progressRef} materials={materials} />
       ))}

--- a/components/hero/scene3d/HeroCanvas.tsx
+++ b/components/hero/scene3d/HeroCanvas.tsx
@@ -1,22 +1,66 @@
 "use client";
 
+import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { EffectComposer, Bloom } from "@react-three/postprocessing";
 import { CloudCore } from "./CloudCore";
 import { ACCENT_BLUE } from "./materials";
 
-export function HeroCanvas({ progressRef }: { progressRef: React.MutableRefObject<number> }) {
+type HeroCanvasProps = {
+  progressRef: React.MutableRefObject<number>;
+  /**
+   * Fired once if the WebGL context is lost after creation (GPU driver
+   * reset/crash, some mobile browsers reclaiming contexts on backgrounding).
+   * Left unhandled, a lost context just freezes the canvas as a permanent
+   * blank/frozen rectangle. The parent (IntroSequence) uses this to unmount
+   * the Canvas entirely so nothing dead is left in the tree.
+   */
+  onContextLost?: () => void;
+};
+
+export function HeroCanvas({ progressRef, onContextLost }: HeroCanvasProps) {
+  // Coarse-pointer (touch) devices commonly report devicePixelRatio 2-3;
+  // combined with a full-viewport EffectComposer/Bloom pass that's a
+  // meaningfully heavier per-frame cost than desktop, on exactly the class
+  // of device most likely to visibly stutter. Clamp the upper DPR bound
+  // lower there. Reading matchMedia directly in the initializer is safe:
+  // HeroCanvas is only ever mounted client-side (IntroSequence dynamic-
+  // imports it with `ssr: false`), so there's no SSR/hydration mismatch to
+  // guard against here.
+  const [dpr] = useState<[number, number]>(() =>
+    typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches
+      ? [1, 1.5]
+      : [1, 2],
+  );
+
   return (
     <Canvas
-      dpr={[1, 2]}
+      dpr={dpr}
       camera={{ position: [0, 0.2, 7.5], fov: 40 }}
       gl={{ antialias: true, alpha: true }}
       style={{ position: "absolute", inset: 0 }}
+      onCreated={({ gl }) => {
+        // preventDefault() opts into WebGL's context-restore contract, but
+        // we don't attempt to restore the scene — we just tell the parent
+        // to unmount it so the rest of the page (IdentityConsole etc.) is
+        // never affected by a dead/frozen context.
+        gl.domElement.addEventListener(
+          "webglcontextlost",
+          (e) => {
+            e.preventDefault();
+            onContextLost?.();
+          },
+          { once: true },
+        );
+      }}
     >
       {/* NO <Environment> here, deliberately: a PMREM envmap (drei
           Environment + Lightformers) made the entire frame render black
-          during the core-ignite window (p≈0.82–0.96) — verified by bisect
-          with screenshots. The rim light below provides the edge definition
+          during the core-ignite window (originally p≈0.82–0.96; the ignite
+          ramp has since been retimed to p≈0.68–0.84, but the underlying
+          PMREM/Bloom interaction that caused the black frame is unrelated to
+          the exact window and still applies) — verified by bisect with
+          screenshots. The rim light below provides the edge definition
           instead, with none of the HDR-specular blowup risk. */}
       <ambientLight intensity={0.3} />
       <directionalLight position={[4, 5, 3]} intensity={0.7} />
@@ -24,8 +68,8 @@ export function HeroCanvas({ progressRef }: { progressRef: React.MutableRefObjec
       <directionalLight position={[-5, 2, -4]} intensity={0.9} color={ACCENT_BLUE} />
       <CloudCore progressRef={progressRef} />
       {/* multisampling=0: MSAA render targets are a known silent-black
-          failure mode on software/weak GPUs; dpr [1,2] + native AA +
-          mipmapBlur bloom cover edge quality without that risk. */}
+          failure mode on software/weak GPUs; the dpr clamp above + native AA
+          + mipmapBlur bloom cover edge quality without that risk. */}
       <EffectComposer multisampling={0}>
         <Bloom intensity={0.5} luminanceThreshold={0.35} luminanceSmoothing={0.9} mipmapBlur />
       </EffectComposer>

--- a/components/hero/scene3d/blocks-data.ts
+++ b/components/hero/scene3d/blocks-data.ts
@@ -2,6 +2,8 @@
 // Math.random() here (or anywhere in the render path) so SSR and first
 // client paint agree; see IntroSequence's reduced-motion note for why.
 
+import type { Domain } from "./materials";
+
 export type BlockDef = {
   /** Final locked position [x, y, z]. */
   pos: [number, number, number];
@@ -9,31 +11,67 @@ export type BlockDef = {
   scale: number;
   /** Stagger offset (0-1) within the assembly window — larger arrives later. */
   delay: number;
+  /**
+   * Which technical domain this module belongs to, per DESIGN.md's
+   * Domain-Color Rule (blue=architecture, cyan=platform/DevOps, orange=
+   * FinOps/cost). Drives both the accent-strip color and the chassis
+   * silhouette (see BOX_ARGS) so the assembly reads as three disciplines,
+   * not eleven identical boxes with a single recolored stripe.
+   */
+  domain: Domain;
 };
 
 // Cloud silhouette built from overlapping rounded-box "server module" lobes:
 // a raised center lobe, two shoulder lobes, two outer lobes, a flatter base
 // row underneath, and two small accent chips floating on top.
 //
-// Single accent color (blue = architecture, per this project's Domain-Color
-// Rule in DESIGN.md: each accent maps to one technical domain and the three
-// are never mixed decoratively on one element/composition).
+// Domain assignment is deliberate, not decorative: architecture (blue) is
+// the majority and forms the cloud's upper mass — the discipline everything
+// else sits on top of. Platform/DevOps (cyan) modules sit low, in the
+// foundation row — the operational layer infrastructure runs on. FinOps
+// (orange) appears sparingly, as a floating chip and one foundation module —
+// cost visibility sits alongside the platform it measures, never dominates
+// it. This mirrors the real proportions of the work (architecture-led,
+// platform-supported, FinOps-informed), not an even three-way split.
+// Delays are scaled to finish assembly (delay + CloudCore's SPAN, currently
+// 0.3) by p≈0.62 — well before the core's ignite ramp starts at p=0.68 — so
+// "assembly" and "platform activation" read as two sequential beats within
+// the shortened (130vh) pinned track, not one long overlapping blur.
 export const BLOCKS: BlockDef[] = [
-  // Top row — the cloud's puffs, tallest/largest in the center
-  { pos: [-1.8, 0.1, 0.3], scale: 0.85, delay: 0.0 },
-  { pos: [-0.9, 0.35, -0.2], scale: 1.0, delay: 0.08 },
-  { pos: [0, 0.55, 0.4], scale: 1.18, delay: 0.16 },
-  { pos: [0.9, 0.35, -0.1], scale: 1.0, delay: 0.08 },
-  { pos: [1.8, 0.05, 0.3], scale: 0.85, delay: 0.0 },
-  // Base row — flatter, sits lower, gives the cloud its underside
-  { pos: [-1.3, -0.55, 0.1], scale: 0.75, delay: 0.22 },
-  { pos: [-0.4, -0.65, 0.35], scale: 0.8, delay: 0.3 },
-  { pos: [0.5, -0.65, 0.15], scale: 0.8, delay: 0.3 },
-  { pos: [1.3, -0.55, -0.05], scale: 0.75, delay: 0.22 },
-  // Small accent chips floating just above the main mass
-  { pos: [-0.5, 0.95, 0.5], scale: 0.4, delay: 0.42 },
-  { pos: [0.6, 1.0, 0.2], scale: 0.4, delay: 0.42 },
+  // Top row — the cloud's puffs, tallest/largest in the center. Architecture.
+  { pos: [-1.8, 0.1, 0.3], scale: 0.85, delay: 0.08, domain: "blue" },
+  { pos: [-0.9, 0.35, -0.2], scale: 1.0, delay: 0.13, domain: "blue" },
+  { pos: [0, 0.55, 0.4], scale: 1.18, delay: 0.17, domain: "blue" },
+  { pos: [0.9, 0.35, -0.1], scale: 1.0, delay: 0.13, domain: "cyan" },
+  { pos: [1.8, 0.05, 0.3], scale: 0.85, delay: 0.08, domain: "blue" },
+  // Base row — flatter, sits lower, gives the cloud its underside. This is
+  // the operational foundation: platform/DevOps modules with one FinOps
+  // module reading the cost of what runs on them.
+  { pos: [-1.3, -0.55, 0.1], scale: 0.75, delay: 0.21, domain: "cyan" },
+  { pos: [-0.4, -0.65, 0.35], scale: 0.8, delay: 0.25, domain: "orange" },
+  { pos: [0.5, -0.65, 0.15], scale: 0.8, delay: 0.25, domain: "blue" },
+  { pos: [1.3, -0.55, -0.05], scale: 0.75, delay: 0.21, domain: "cyan" },
+  // Small accent chips floating just above the main mass — a FinOps cost
+  // signal and a platform/observability signal, visibly smaller than the
+  // structural modules since they're signals riding on the architecture,
+  // not load-bearing parts of it.
+  { pos: [-0.5, 0.95, 0.5], scale: 0.4, delay: 0.32, domain: "orange" },
+  { pos: [0.6, 1.0, 0.2], scale: 0.4, delay: 0.32, domain: "cyan" },
 ];
+
+// Per-domain chassis proportions: same rounded-corner language throughout
+// (nothing reads as a different kit of parts), but the aspect ratio hints at
+// what each domain physically resembles — without adding new geometry or
+// textures. Architecture keeps the original soft cloud-lobe cube. Platform/
+// DevOps modules are wider and flatter, closer to a stacked container/rack
+// unit. FinOps modules are narrower and taller, closer to a ledger tile or
+// a meter. Base dimensions before the block's own uniform `scale` multiplies
+// them further.
+export const BOX_ARGS: Record<Domain, [number, number, number]> = {
+  blue: [0.95, 0.6, 0.95],
+  cyan: [1.12, 0.42, 0.9],
+  orange: [0.72, 0.85, 0.68],
+};
 
 /** Deterministic pseudo-random scatter offset for block i (no Math.random). */
 export function scatterOffset(i: number): [number, number, number, number, number, number] {

--- a/components/hero/scene3d/materials.tsx
+++ b/components/hero/scene3d/materials.tsx
@@ -1,12 +1,35 @@
 import * as THREE from "three";
 
-// Single accent for the whole scene: blue = architecture, per this
-// project's Domain-Color Rule (DESIGN.md) — each accent maps to one
-// technical domain and the three are never mixed decoratively on one
-// element. Mirrors --color-blue in app/globals.css (kept as a plain hex
-// since three.js materials don't read CSS custom properties).
+// The Domain-Color Rule (DESIGN.md): blue = cloud architecture, cyan =
+// platform engineering/DevOps/data, orange = FinOps/cost. The 3D assembly
+// now encodes this directly in its own geometry (see blocks-data.ts), not
+// only in the 2D DOM icon overlay layered on top in intro-sequence.tsx.
+// Architecture (blue) stays the dominant/majority domain — it's the
+// chassis's "home" color and the core's color — cyan and orange appear only
+// on a minority of accent strips, so the scene reads as one system with
+// three legible specialities, not a rainbow.
+// Mirrors --color-blue/--color-cyan/--color-orange in app/globals.css (kept
+// as plain hex since three.js materials don't read CSS custom properties).
 export const ACCENT_BLUE = "#3b82f6";
+export const ACCENT_CYAN = "#22b8c4";
+export const ACCENT_ORANGE = "#f59e5b";
 
+export type Domain = "blue" | "cyan" | "orange";
+
+const DOMAIN_COLOR: Record<Domain, string> = {
+  blue: ACCENT_BLUE,
+  cyan: ACCENT_CYAN,
+  orange: ACCENT_ORANGE,
+};
+
+export function domainColor(domain: Domain): string {
+  return DOMAIN_COLOR[domain];
+}
+
+// Chassis stays a single neutral dark shell regardless of domain — the
+// module's "body" is quiet by design; only its accent strip declares which
+// domain it belongs to. This keeps the composition disciplined (one bold
+// signal per element) instead of tinting every surface.
 export function chassisMaterial() {
   return new THREE.MeshStandardMaterial({
     color: "#0f1520",
@@ -15,16 +38,19 @@ export function chassisMaterial() {
   });
 }
 
-export function accentMaterial(emissiveIntensity = 1.05) {
+export function accentMaterial(domain: Domain, emissiveIntensity = 1.05) {
+  const color = domainColor(domain);
   return new THREE.MeshStandardMaterial({
-    color: ACCENT_BLUE,
-    emissive: ACCENT_BLUE,
+    color,
+    emissive: color,
     emissiveIntensity,
     metalness: 0.2,
     roughness: 0.4,
   });
 }
 
+// The core is the architecture domain's hub — it stays blue: the dominant,
+// central discipline the whole assembly orbits around.
 export function coreMaterial() {
   return new THREE.MeshStandardMaterial({
     color: ACCENT_BLUE,

--- a/components/hero/scene3d/webgl-boundary.tsx
+++ b/components/hero/scene3d/webgl-boundary.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+};
+
+type State = {
+  failed: boolean;
+};
+
+/**
+ * Hard requirement per CLAUDE.md: a WebGL/Canvas init failure must never
+ * take down the page — IdentityConsole has to render regardless. There was
+ * no error boundary anywhere in this app (no app/error.tsx / global-error.tsx
+ * exist), so an R3F Canvas creation failure (GPU driver crash, hardware
+ * acceleration disabled, restrictive browser flags, some headless/CI
+ * environments) would previously throw with nothing to catch it — surfacing
+ * Next's generic client-exception overlay for the WHOLE page.
+ *
+ * This boundary is scoped tightly around `<HeroCanvas />` only (see
+ * IntroSequence): IdentityConsole and everything else on the page is a
+ * sibling outside it, so a Canvas failure degrades to "no 3D scene" — the
+ * canvas wrapper div stays in the tree empty — rather than blanking
+ * anything else. Class component is required here: React has no hook
+ * equivalent of getDerivedStateFromError/componentDidCatch.
+ */
+export class WebGLBoundary extends Component<Props, State> {
+  state: State = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("IntroSequence: 3D scene failed to initialize, hiding it.", error);
+    }
+  }
+
+  render() {
+    if (this.state.failed) return null;
+    return this.props.children;
+  }
+}

--- a/hooks/use-typewriter.ts
+++ b/hooks/use-typewriter.ts
@@ -4,20 +4,30 @@ import { useEffect, useState } from "react";
 
 /**
  * Returns the portion of `text` revealed so far and whether typing is done.
- * Starts after `startDelay` ms, types one character every `charDelay` ms.
- * Under prefers-reduced-motion: instantly reveals full text.
+ * Starts after `startDelay` ms (once `start` is true), types one character
+ * every `charDelay` ms. Under prefers-reduced-motion: instantly reveals full
+ * text. `start` defaults to true (fires on mount, the original behavior) —
+ * pass `start: false` until some later trigger (e.g. scroll-arrival) should
+ * kick the reveal off, so the caller controls *when* the clock starts
+ * without owning the char-by-char ticking logic itself.
  */
 export function useTypewriter(
   text: string,
-  { charDelay = 55, startDelay = 0, skip = false }: { charDelay?: number; startDelay?: number; skip?: boolean } = {}
+  {
+    charDelay = 55,
+    startDelay = 0,
+    skip = false,
+    start = true,
+  }: { charDelay?: number; startDelay?: number; skip?: boolean; start?: boolean } = {}
 ): { displayed: string; done: boolean } {
   const [idx, setIdx] = useState(skip ? text.length : 0);
 
   useEffect(() => {
     if (skip) { setIdx(text.length); return; }
+    if (!start) { setIdx(0); return; }
     setIdx(0);
     let frame: ReturnType<typeof setTimeout>;
-    const start = setTimeout(() => {
+    const startTimer = setTimeout(() => {
       let i = 0;
       const tick = () => {
         i++;
@@ -26,8 +36,8 @@ export function useTypewriter(
       };
       frame = setTimeout(tick, charDelay);
     }, startDelay);
-    return () => { clearTimeout(start); clearTimeout(frame); };
-  }, [text, charDelay, startDelay, skip]);
+    return () => { clearTimeout(startTimer); clearTimeout(frame); };
+  }, [text, charDelay, startDelay, skip, start]);
 
   return { displayed: text.slice(0, idx), done: idx >= text.length };
 }


### PR DESCRIPTION
## Summary

A 5-dimension multi-agent review (product/conversion, 3D art direction, motion choreography, mobile/a11y, performance/resilience) of the `IntroSequence` scroll-scrubbed hero entrance surfaced real regressions against the component's own documented intent, plus a generic-feeling 3D scene. This addresses all of it, implemented sequentially (each stage building on the last) and independently verified.

**Art direction** (`materials.tsx`, `blocks-data.ts`, `CloudCore.tsx`)
- The Domain-Color Rule (blue=architecture, cyan=platform/DevOps, orange=FinOps/cost) now lives in the 3D geometry itself — block accent strips and proportions vary by domain instead of one uniform blue.
- Replaced the `Icosahedron` core (a discordant "power gem" sitting inside soft cloud-lobe blocks) with a `RoundedBox` matching the chassis language.
- Removed the ambient `Sparkles` field — generic 3D-hero filler carrying zero domain information.
- Finale connector lines/icon borders now tint to match each provider's domain (Kubernetes/Docker → cyan).

**Motion choreography** (`intro-sequence.tsx`, `CloudCore.tsx`, `blocks-data.ts`)
- Track height cut from `220vh` back to CLAUDE.md's documented, scan-time-justified `120vh` (had regressed to nearly double that).
- Re-timed the five-beat arc so segments stop overlapping: identity clears before the canvas ramps, assembly finishes before ignite, ignite visibly starts before connectors draw.
- Idle bob/drift now tapers once the scene settles instead of running at full amplitude forever.
- Fixed `IdentityConsole` arriving pre-animated off-screen: its entrance + typewriter now gate on scroll-arrival (`IntersectionObserver`) instead of mount.

**Product/conversion** (`intro-sequence.tsx`)
- Downgraded the intro's duplicated full-name treatment from Display to Title scale — DESIGN.md reserves Display type for one instance per page (now `IdentityConsole`'s typewriter).
- Wired the previously-dead "scroll progress" hairline to real progress.

**Mobile + accessibility** (`intro-sequence.tsx`)
- The 2D orbit-icon/connection-line overlay now scales in step with the 3D scene's own aspect-based fit, instead of floating at full desktop radius around a shrunk cloud on narrow viewports.
- Added the same dual reduced-motion check (OS media query + `data-reduce-motion`) already used by `matrix-rain.tsx`.
- Fixed translation-length overflow on the role line; added landscape/safe-area handling.

**Performance + resilience** (`webgl-boundary.tsx` new, `HeroCanvas.tsx`, `intro-sequence.tsx`)
- Added a WebGL error boundary + context-loss handling — previously a Canvas failure had no fallback anywhere in the app and would have taken the whole page down.
- Canvas now unmounts once scrolled well out of view instead of rendering at `frameloop="always"` for the rest of the session.
- Mobile DPR clamp for the full-viewport Bloom pass.
- Fixed an SSR/CSR hydration-mismatch risk on the reduced-motion gate.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes (0 errors, pre-existing unrelated warnings only)
- [x] `npm run build` succeeds
- [x] Visually verified via Playwright screenshots across the actual scroll-progress range (0%, ~18%, ~36%, ~58%, ~76%, ~93%, 100%), confirming: domain-colored blocks assemble into a cloud silhouette, the core ignites before the 6 provider icons (AWS/Azure/GCP/K8s/Terraform/Docker) connect in with domain-tinted lines, the scene settles to a calm glow, and the pin releases directly into `IdentityConsole`
- [x] Verified `prefers-reduced-motion` skips straight to the full real hero (name, stats, CTAs all present immediately)
- [x] Verified mobile (390×844): 2D overlay scales with the 3D cloud instead of floating at desktop radius


---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hero animations and typewriter content now begin as the section enters the viewport.
  - Added responsive 3D visuals with domain-specific colors, improved scaling, and updated motion timing.
  - Scroll progress is now reflected in an animated progress indicator.
- **Improvements**
  - Reduced-motion preferences and settings are applied more consistently.
  - Improved performance on mobile and narrow screens.
  - WebGL failures now gracefully fall back to the 2D experience without disrupting the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->