### PR TITLE
Fix 3D intro animation reset on scroll-back

### DIFF
--- a/components/hero/intro-sequence.tsx
+++ b/components/hero/intro-sequence.tsx
@@ -233,6 +233,12 @@ export function IntroSequence() {
               (window as unknown as { __introProgress?: number }).__introProgress = self.progress;
             }
           },
+          onRefresh: () => {
+            progressRef.current = 0;
+            if (progressBarRef.current) {
+              progressBarRef.current.style.transform = `scaleX(0)`;
+            }
+          },
         },
       });
       // Pad to duration 1 so position parameters below read as scroll fractions.
@@ -281,7 +287,16 @@ export function IntroSequence() {
       }
     }, trackRef);
 
-    return () => ctx.revert();
+    // Refresh ScrollTrigger on window resize to recalculate pin/scroll positions
+    const handleResize = () => {
+      ScrollTrigger.refresh();
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      ctx.revert();
+    };
   }, [shouldReduce]);
 
   if (shouldReduce) return null;


### PR DESCRIPTION
Fixes the IntroSequence animation freezing after scrolling down and back to top.

Changes:
- Add onRefresh callback to reset progressRef when ScrollTrigger recalculates
- Add window resize listener to refresh ScrollTrigger on layout changes
- Ensures animation resets properly on scroll reversals and viewport changes