### PR TITLE
Fix 3D hero vanishing after scroll-away, and make the scene theme-aware

### DIFF
--- a/components/hero/intro-sequence.tsx
+++ b/components/hero/intro-sequence.tsx
@@ -100,6 +100,12 @@ export function IntroSequence() {
   const progressRef = useRef(0);
   const [overlayFit, setOverlayFit] = useState(1);
   const [siteReduced, setSiteReduced] = useState(false);
+  // The 3D scene has two deliberate material identities (materials.ts SCENE):
+  // a glowing data-center void in dark, a crisp light-grey architecture-diagram
+  // look in light. Default "dark" (this repo is dark-first and the Canvas is
+  // client-only, so no SSR markup depends on it); a class-attribute observer
+  // re-skins the scene live if the visitor toggles the theme mid-view.
+  const [theme, setTheme] = useState<"light" | "dark">("dark");
   // SSR (and the very first, hydrating client render) must agree, or React
   // logs a hydration mismatch and the 120vh track visibly collapses/re-
   // expands. `useReducedMotion()` returns false during SSR but can already
@@ -170,6 +176,18 @@ export function IntroSequence() {
     check();
     const mo = new MutationObserver(check);
     mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-reduce-motion"] });
+    return () => mo.disconnect();
+  }, []);
+
+  // Track the site theme (next-themes toggles `.light`/`.dark` on <html>) so
+  // the 3D scene can flip between its two material identities live. Read post-
+  // mount + observe the class attribute for mid-view toggles.
+  useEffect(() => {
+    const check = () =>
+      setTheme(document.documentElement.classList.contains("light") ? "light" : "dark");
+    check();
+    const mo = new MutationObserver(check);
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
     return () => mo.disconnect();
   }, []);
 
@@ -305,6 +323,7 @@ export function IntroSequence() {
               <HeroCanvas
                 progressRef={progressRef}
                 active={canvasVisible}
+                theme={theme}
                 onContextLost={() => setCanvasFailed(true)}
               />
             </WebGLBoundary>

--- a/components/hero/intro-sequence.tsx
+++ b/components/hero/intro-sequence.tsx
@@ -122,12 +122,14 @@ export function IntroSequence() {
   // Perf/resilience: once this 120vh track has scrolled well out of view
   // (visitor has moved on to Story/ExperienceTimeline/etc.), there is no
   // reason for the R3F Canvas to keep rendering every frame indefinitely.
-  // Unmounting HeroCanvas (rather than fiddling with `frameloop`) stops the
-  // render loop outright and runs CloudCore's existing material-disposal
-  // cleanup, reclaiming the GPU resources; remounting on scroll-back reads
-  // live from `progressRef` so it snaps back to the correct assembly state
-  // with no extra bookkeeping. Generous rootMargin avoids any pop during
-  // the scroll-through itself, only unmounting once genuinely far away.
+  // This PAUSES the render loop (HeroCanvas `frameloop="never"`) rather than
+  // unmounting the Canvas: unmounting disposes the WebGL context, which fires
+  // `webglcontextlost`, and scroll-away/scroll-back churn either trips the
+  // context-lost handler below (permanently blanking the scene) or exhausts
+  // the browser's live-context budget. Pausing keeps the context alive (a few
+  // MB idle) while doing zero per-frame work off-screen — the actual cost the
+  // gating targets. The scene reads live from `progressRef`, so on resume it
+  // renders the correct assembly state on its next frame with no bookkeeping.
   const [canvasVisible, setCanvasVisible] = useState(true);
 
   // Mirrors CloudCore's own aspect-aware `fit` (scene3d/CloudCore.tsx) so the
@@ -291,14 +293,20 @@ export function IntroSequence() {
       <div ref={stageRef} className="relative h-dvh w-full overflow-hidden bg-[var(--color-surface-0)]">
         {/* 3D scene — faint at rest so the identity block owns the first read.
             Wrapped in WebGLBoundary (hard requirement: a Canvas init failure
-            must never take the page down) and gated on canvasVisible/
-            canvasFailed — either condition simply renders an empty wrapper
-            div, leaving the 2D layer and the handoff into IdentityConsole
-            completely unaffected. */}
+            must never take the page down). The Canvas stays mounted for the
+            whole visit and only its render loop is paused off-screen (via the
+            `active` prop → frameloop) — see the canvasVisible note above for
+            why this must NOT be an unmount. Only a genuine, unrecoverable
+            context loss (canvasFailed) actually removes it, leaving an empty
+            wrapper div with the 2D layer and IdentityConsole handoff intact. */}
         <div ref={canvasWrapRef} className="absolute inset-0" style={{ opacity: 0.16 }}>
-          {!canvasFailed && canvasVisible && (
+          {!canvasFailed && (
             <WebGLBoundary>
-              <HeroCanvas progressRef={progressRef} onContextLost={() => setCanvasFailed(true)} />
+              <HeroCanvas
+                progressRef={progressRef}
+                active={canvasVisible}
+                onContextLost={() => setCanvasFailed(true)}
+              />
             </WebGLBoundary>
           )}
         </div>

--- a/components/hero/scene3d/CloudCore.tsx
+++ b/components/hero/scene3d/CloudCore.tsx
@@ -5,7 +5,7 @@ import { useFrame } from "@react-three/fiber";
 import { RoundedBox } from "@react-three/drei";
 import * as THREE from "three";
 import { BLOCKS, BOX_ARGS, scatterOffset } from "./blocks-data";
-import { chassisMaterial, accentMaterial, coreMaterial, ACCENT_BLUE, type Domain } from "./materials";
+import { chassisMaterial, accentMaterial, coreMaterial, SCENE, type Domain, type Theme } from "./materials";
 
 function easeOutCubic(t: number) {
   return 1 - Math.pow(1 - t, 3);
@@ -86,12 +86,15 @@ function Block({ index, progressRef, materials }: { index: number; progressRef: 
   );
 }
 
-export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
-  const chassis = useMemo(() => chassisMaterial(), []);
-  const accentBlue = useMemo(() => accentMaterial("blue"), []);
-  const accentCyan = useMemo(() => accentMaterial("cyan"), []);
-  const accentOrange = useMemo(() => accentMaterial("orange"), []);
-  const coreMat = useMemo(() => coreMaterial(), []);
+export function CloudCore({ progressRef, theme = "dark" }: { progressRef: ProgressRef; theme?: Theme }) {
+  // Materials are rebuilt when the theme flips (deps: [theme]) so a live
+  // light/dark toggle re-skins the scene; the old set is disposed by the
+  // cleanup effect below, which re-runs on the same dependency change.
+  const chassis = useMemo(() => chassisMaterial(theme), [theme]);
+  const accentBlue = useMemo(() => accentMaterial("blue", theme), [theme]);
+  const accentCyan = useMemo(() => accentMaterial("cyan", theme), [theme]);
+  const accentOrange = useMemo(() => accentMaterial("orange", theme), [theme]);
+  const coreMat = useMemo(() => coreMaterial(theme), [theme]);
   const rootRef = useRef<THREE.Group>(null);
   const coreRef = useRef<THREE.Mesh>(null);
   const lightRef = useRef<THREE.PointLight>(null);
@@ -99,10 +102,11 @@ export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
     () => ({ chassis, accent: { blue: accentBlue, cyan: accentCyan, orange: accentOrange } }),
     [chassis, accentBlue, accentCyan, accentOrange],
   );
+  const scene = SCENE[theme];
 
-  // Materials created outside R3F's reconciler aren't auto-disposed —
-  // free the GPU resources if the scene ever unmounts (e.g. a live
-  // prefers-reduced-motion toggle).
+  // Materials created outside R3F's reconciler aren't auto-disposed — free the
+  // GPU resources when the scene unmounts OR when the theme flips (the memo'd
+  // materials become new objects, so this cleanup disposes the superseded set).
   useEffect(() => {
     return () => {
       chassis.dispose();
@@ -151,19 +155,22 @@ export function CloudCore({ progressRef }: { progressRef: ProgressRef }) {
     // peak brightness indefinitely.
     const ignite = smoothstep(0.68, 0.84, p);
     const calm = 1 - smoothstep(0.88, 1, p) * 0.4;
-    const intensity = (0.6 + ignite * 3) * calm;
+    // Ignite/point-light ranges are per-theme (see SCENE): the dark void wants
+    // a strong bloom-fed flare, but on white that same range blows out to a
+    // muddy haze, so light uses a gentler ramp.
+    const intensity = (scene.coreIgnite.base + ignite * scene.coreIgnite.scale) * calm;
     if (coreRef.current) {
       coreRef.current.scale.setScalar(0.85 + ignite * 0.25);
       (coreRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity = intensity;
     }
     if (lightRef.current) {
-      lightRef.current.intensity = 1.2 + ignite * 6;
+      lightRef.current.intensity = scene.point.base + ignite * scene.point.ignite;
     }
   });
 
   return (
     <group ref={rootRef}>
-      <pointLight ref={lightRef} position={[0, 0, 0]} color={ACCENT_BLUE} intensity={1.2} distance={8} />
+      <pointLight ref={lightRef} position={[0, 0, 0]} color={scene.point.color} intensity={scene.point.base} distance={8} />
       {/* The control-plane hub: a small rounded module at the center, same
           chassis language (RoundedBox, matching corner radius) as the
           modules docking around it, rather than a faceted crystal — it

--- a/components/hero/scene3d/HeroCanvas.tsx
+++ b/components/hero/scene3d/HeroCanvas.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Canvas } from "@react-three/fiber";
 import { EffectComposer, Bloom } from "@react-three/postprocessing";
 import { CloudCore } from "./CloudCore";
-import { ACCENT_BLUE } from "./materials";
+import { SCENE, type Theme } from "./materials";
 
 type HeroCanvasProps = {
   progressRef: React.MutableRefObject<number>;
@@ -27,9 +27,17 @@ type HeroCanvasProps = {
    * safely treat it as "hide the 3D for this visit."
    */
   onContextLost?: () => void;
+  /**
+   * Current site theme. The scene has two deliberate material/lighting
+   * identities (see materials.ts SCENE): a glowing data-center void in dark, a
+   * crisp light-grey architecture-diagram look in light. Flips live when the
+   * visitor toggles the theme.
+   */
+  theme?: Theme;
 };
 
-export function HeroCanvas({ progressRef, active = true, onContextLost }: HeroCanvasProps) {
+export function HeroCanvas({ progressRef, active = true, onContextLost, theme = "dark" }: HeroCanvasProps) {
+  const scene = SCENE[theme];
   // Coarse-pointer (touch) devices commonly report devicePixelRatio 2-3;
   // combined with a full-viewport EffectComposer/Bloom pass that's a
   // meaningfully heavier per-frame cost than desktop, on exactly the class
@@ -74,16 +82,20 @@ export function HeroCanvas({ progressRef, active = true, onContextLost }: HeroCa
           the exact window and still applies) — verified by bisect with
           screenshots. The rim light below provides the edge definition
           instead, with none of the HDR-specular blowup risk. */}
-      <ambientLight intensity={0.3} />
-      <directionalLight position={[4, 5, 3]} intensity={0.7} />
-      {/* Rim light from behind-left — separates dark chassis edges from the void bg */}
-      <directionalLight position={[-5, 2, -4]} intensity={0.9} color={ACCENT_BLUE} />
-      <CloudCore progressRef={progressRef} />
+      {/* Lighting + bloom are theme-driven (materials.ts SCENE): dark leans on
+          a strong rim + generous bloom to carve glowing edges from the void;
+          light leans on high even ambient fill so the grey module tiles read
+          as lit hardware, with a restrained rim/bloom so white doesn't haze. */}
+      <ambientLight intensity={scene.ambient} />
+      <directionalLight position={[4, 5, 3]} intensity={scene.dir} />
+      {/* Rim light from behind-left — separates chassis edges from the bg */}
+      <directionalLight position={[-5, 2, -4]} intensity={scene.rim} color={scene.rimColor} />
+      <CloudCore progressRef={progressRef} theme={theme} />
       {/* multisampling=0: MSAA render targets are a known silent-black
           failure mode on software/weak GPUs; the dpr clamp above + native AA
           + mipmapBlur bloom cover edge quality without that risk. */}
       <EffectComposer multisampling={0}>
-        <Bloom intensity={0.5} luminanceThreshold={0.35} luminanceSmoothing={0.9} mipmapBlur />
+        <Bloom intensity={scene.bloom.intensity} luminanceThreshold={scene.bloom.threshold} luminanceSmoothing={0.9} mipmapBlur />
       </EffectComposer>
     </Canvas>
   );

--- a/components/hero/scene3d/HeroCanvas.tsx
+++ b/components/hero/scene3d/HeroCanvas.tsx
@@ -9,16 +9,27 @@ import { ACCENT_BLUE } from "./materials";
 type HeroCanvasProps = {
   progressRef: React.MutableRefObject<number>;
   /**
-   * Fired once if the WebGL context is lost after creation (GPU driver
-   * reset/crash, some mobile browsers reclaiming contexts on backgrounding).
-   * Left unhandled, a lost context just freezes the canvas as a permanent
-   * blank/frozen rectangle. The parent (IntroSequence) uses this to unmount
-   * the Canvas entirely so nothing dead is left in the tree.
+   * When false, the render loop is paused (`frameloop="never"`) — the Canvas
+   * stays mounted (context intact) but does zero per-frame work while the
+   * intro is scrolled out of view. The parent flips this from an
+   * IntersectionObserver. This is deliberately NOT an unmount: tearing the
+   * Canvas down disposes the WebGL context, which fires `webglcontextlost`,
+   * and repeated scroll-away/scroll-back churn either trips that handler or
+   * exhausts the browser's live-context budget — both leave the 3D
+   * permanently blank. Pausing the loop keeps the context alive and cheap.
+   */
+  active?: boolean;
+  /**
+   * Fired once if the WebGL context is genuinely lost after creation (GPU
+   * driver reset/crash, browser reclaiming a backgrounded context). Because
+   * the Canvas is no longer unmounted on scroll (see `active`), this now only
+   * fires for real failures, not for our own teardown — so the parent can
+   * safely treat it as "hide the 3D for this visit."
    */
   onContextLost?: () => void;
 };
 
-export function HeroCanvas({ progressRef, onContextLost }: HeroCanvasProps) {
+export function HeroCanvas({ progressRef, active = true, onContextLost }: HeroCanvasProps) {
   // Coarse-pointer (touch) devices commonly report devicePixelRatio 2-3;
   // combined with a full-viewport EffectComposer/Bloom pass that's a
   // meaningfully heavier per-frame cost than desktop, on exactly the class
@@ -36,6 +47,7 @@ export function HeroCanvas({ progressRef, onContextLost }: HeroCanvasProps) {
   return (
     <Canvas
       dpr={dpr}
+      frameloop={active ? "always" : "never"}
       camera={{ position: [0, 0.2, 7.5], fov: 40 }}
       gl={{ antialias: true, alpha: true }}
       style={{ position: "absolute", inset: 0 }}

--- a/components/hero/scene3d/materials.tsx
+++ b/components/hero/scene3d/materials.tsx
@@ -2,61 +2,123 @@ import * as THREE from "three";
 
 // The Domain-Color Rule (DESIGN.md): blue = cloud architecture, cyan =
 // platform engineering/DevOps/data, orange = FinOps/cost. The 3D assembly
-// now encodes this directly in its own geometry (see blocks-data.ts), not
-// only in the 2D DOM icon overlay layered on top in intro-sequence.tsx.
-// Architecture (blue) stays the dominant/majority domain — it's the
-// chassis's "home" color and the core's color — cyan and orange appear only
-// on a minority of accent strips, so the scene reads as one system with
-// three legible specialities, not a rainbow.
-// Mirrors --color-blue/--color-cyan/--color-orange in app/globals.css (kept
-// as plain hex since three.js materials don't read CSS custom properties).
+// encodes this directly in its own geometry (see blocks-data.ts), not only in
+// the 2D DOM icon overlay layered on top in intro-sequence.tsx. Architecture
+// (blue) stays the dominant/majority domain — it's the chassis's "home" color
+// and the core's color — cyan and orange appear only on a minority of accent
+// strips, so the scene reads as one system with three legible specialities,
+// not a rainbow.
+//
+// The scene has TWO deliberate material identities, one per theme, not one
+// look that merely survives on both backgrounds:
+//   • dark  — glowing modules in a data-center void: near-black metal chassis,
+//             bright emissive accent strips, blue rim light, generous bloom.
+//   • light — a crisp isometric architecture diagram on paper: light cool-grey
+//             module tiles, saturated (not neon) painted indicator strips,
+//             even ambient fill, restrained bloom. On white, the dark-void
+//             recipe reads as heavy black bricks; this one reads as intentional
+//             light-mode hardware.
+// Both use the site's own accents (--color-blue/cyan/orange in globals.css) at
+// each theme's value — kept as plain hex since three.js materials don't read
+// CSS custom properties.
+
+export type Theme = "light" | "dark";
+
 export const ACCENT_BLUE = "#3b82f6";
 export const ACCENT_CYAN = "#22b8c4";
 export const ACCENT_ORANGE = "#f59e5b";
 
 export type Domain = "blue" | "cyan" | "orange";
 
-const DOMAIN_COLOR: Record<Domain, string> = {
+// Bright, glow-forward accents for the dark void.
+const DOMAIN_COLOR_DARK: Record<Domain, string> = {
   blue: ACCENT_BLUE,
   cyan: ACCENT_CYAN,
   orange: ACCENT_ORANGE,
 };
+// The site's own light-mode accents — saturated enough to read as painted
+// indicators on white without the neon glare the dark hexes get there.
+const DOMAIN_COLOR_LIGHT: Record<Domain, string> = {
+  blue: "#1f6fe0",
+  cyan: "#0e9aa3",
+  orange: "#e0641b",
+};
 
-export function domainColor(domain: Domain): string {
-  return DOMAIN_COLOR[domain];
+export function domainColor(domain: Domain, theme: Theme = "dark"): string {
+  return (theme === "light" ? DOMAIN_COLOR_LIGHT : DOMAIN_COLOR_DARK)[domain];
 }
 
-// Chassis stays a single neutral dark shell regardless of domain — the
-// module's "body" is quiet by design; only its accent strip declares which
-// domain it belongs to. This keeps the composition disciplined (one bold
-// signal per element) instead of tinting every surface.
-export function chassisMaterial() {
-  return new THREE.MeshStandardMaterial({
-    color: "#0f1520",
-    metalness: 0.6,
-    roughness: 0.35,
-  });
+// Chassis stays a single neutral shell regardless of domain — the module's
+// "body" is quiet by design; only its accent strip declares which domain it
+// belongs to. Dark: near-black metal for the void. Light: a mid cool-grey tile
+// that has real presence on white (darker than the page's surface-1) and reads
+// as matte hardware, not a shiny black slab.
+export function chassisMaterial(theme: Theme) {
+  return theme === "light"
+    ? new THREE.MeshStandardMaterial({ color: "#c2ccd8", metalness: 0.15, roughness: 0.62 })
+    : new THREE.MeshStandardMaterial({ color: "#0f1520", metalness: 0.6, roughness: 0.35 });
 }
 
-export function accentMaterial(domain: Domain, emissiveIntensity = 1.05) {
-  const color = domainColor(domain);
+export function accentMaterial(domain: Domain, theme: Theme) {
+  const color = domainColor(domain, theme);
+  // Lower emissive in light: on white the strip should read as a painted
+  // indicator, not a glare; in the dark void it's a light coming online.
   return new THREE.MeshStandardMaterial({
     color,
     emissive: color,
-    emissiveIntensity,
-    metalness: 0.2,
-    roughness: 0.4,
+    emissiveIntensity: theme === "light" ? 0.55 : 1.05,
+    metalness: theme === "light" ? 0.1 : 0.2,
+    roughness: theme === "light" ? 0.5 : 0.4,
   });
 }
 
-// The core is the architecture domain's hub — it stays blue: the dominant,
-// central discipline the whole assembly orbits around.
-export function coreMaterial() {
+// The core is the architecture domain's hub — always blue, the dominant,
+// central discipline the whole assembly orbits around. Softer emissive in
+// light so it's a solid saturated hub rather than a bloom blaster on white.
+export function coreMaterial(theme: Theme) {
+  const color = domainColor("blue", theme);
   return new THREE.MeshStandardMaterial({
-    color: ACCENT_BLUE,
-    emissive: ACCENT_BLUE,
-    emissiveIntensity: 1,
+    color,
+    emissive: color,
+    emissiveIntensity: theme === "light" ? 0.7 : 1,
     metalness: 0.1,
     roughness: 0.2,
   });
 }
+
+// Per-theme lighting, bloom, and the core's ignite/point-light ranges. Dark
+// leans on a strong rim + generous bloom to carve glowing edges out of the
+// void; light leans on high even ambient fill (so the grey tiles read as lit
+// hardware, not shadowed) with a restrained rim and bloom so white doesn't
+// turn to muddy haze.
+export const SCENE: Record<
+  Theme,
+  {
+    ambient: number;
+    dir: number;
+    rim: number;
+    rimColor: string;
+    bloom: { intensity: number; threshold: number };
+    point: { base: number; ignite: number; color: string };
+    coreIgnite: { base: number; scale: number };
+  }
+> = {
+  dark: {
+    ambient: 0.3,
+    dir: 0.7,
+    rim: 0.9,
+    rimColor: ACCENT_BLUE,
+    bloom: { intensity: 0.5, threshold: 0.35 },
+    point: { base: 1.2, ignite: 6, color: ACCENT_BLUE },
+    coreIgnite: { base: 0.6, scale: 3 },
+  },
+  light: {
+    ambient: 0.92,
+    dir: 0.5,
+    rim: 0.38,
+    rimColor: "#1f6fe0",
+    bloom: { intensity: 0.22, threshold: 0.68 },
+    point: { base: 0.55, ignite: 2.4, color: "#1f6fe0" },
+    coreIgnite: { base: 0.5, scale: 1.6 },
+  },
+};


### PR DESCRIPTION
Two related commits addressing the 3D hero's light-mode behavior.

## 1. Fix: 3D hero vanishes after scroll-away (blank white void in light mode)

Regression from the hero-entrance overhaul (#37). The perf pass unmounted `<HeroCanvas>` once the intro scrolled out of view (gated on a `canvasVisible` IntersectionObserver). Unmounting an R3F `Canvas` disposes its WebGL context, which fires `webglcontextlost`; the `onContextLost` handler treats that as a real failure and sets `canvasFailed = true`, permanently gating the scene off. So the first scroll-away-and-back killed the 3D for the rest of the visit; repeated churn could also exhaust the browser's live-context budget. In dark mode the dead stage blends into the black page; in light mode it's a glaring white void with only the 2D icons/lines floating — same bug, more obvious on white.

**Fix:** keep the `Canvas` mounted and pause only its render loop off-screen via R3F `frameloop` (new `active` prop), instead of unmounting. Preserves the perf goal (zero per-frame work off-screen) while keeping the context alive, so scrolling back always shows the scene. `onContextLost` stays as a genuine-failure failsafe — it now only fires on a real GPU loss, never on our own teardown.

## 2. Polish: make the 3D scene deliberately theme-aware

With the scene now visible in light mode, its dark-first materials (near-black chassis, blue rim against a "void", generous bloom) read as heavy black bricks on white — visible, but not intentional. The scene now has two deliberate identities:
- **dark** — glowing modules in a data-center void (unchanged).
- **light** — a crisp isometric architecture-diagram look: light cool-grey module tiles, saturated (not neon) painted indicator strips using the site's own light-mode accents, high even ambient fill, restrained rim + bloom.

`materials.ts` exposes per-theme chassis/accent/core factories + a `SCENE` table (lighting, bloom, point-light/core-ignite ranges). `HeroCanvas`/`CloudCore` take a `theme` prop; `IntroSequence` reads the next-themes `.light`/`.dark` class off `<html>` and passes it down, re-skinning the scene **live** when the visitor toggles the theme (materials rebuilt on change, old set disposed — no GPU leak).

## Test plan
- [x] `npx tsc --noEmit`, `npm run lint` (0 errors), `npm run build` all pass
- [x] Playwright: 3D survives 4× scroll-away → scroll-back cycles with **zero** `webglcontextlost` events (before: gone after the first cycle)
- [x] Playwright: dark mode unchanged; light mode renders the grey-tile architecture-diagram look (not a blank void, not black bricks)
- [x] Playwright: clicking the header theme toggle at full-assembly re-skins the scene live from void → diagram with **zero** context loss
