### PR TITLE
Fix Seobility SEO findings: short H1, missing image alt text

### DIFF
--- a/components/hero/identity-console.tsx
+++ b/components/hero/identity-console.tsx
@@ -117,7 +117,7 @@ export function IdentityConsole() {
       <div className="absolute inset-0 -z-10 lg:hidden" aria-hidden>
         <Image
           src="/portrait-mobile.webp"
-          alt=""
+          alt={siteConfig.name}
           fill
           sizes="100vw"
           priority

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -1,6 +1,6 @@
 export const siteConfig = {
   name: "César Augusto Nogueira",
-  firstName: "César A.",
+  firstName: "César Augusto",
   role: "Principal Cloud Architect · Platform Engineering · DevOps · FinOps · AI Infrastructure",
   shortRole: "Principal Cloud Architect & FinOps Consultant",
   tagline:


### PR DESCRIPTION
## Summary

Fixes the single actionable item from the July 16, 2026 Seobility SEO audit of `cesarnogueira.tech` (SEO score 92%, "Page structure" 98%, "Page quality" 92%):

- **H1 heading too short** — the hero H1 rendered as "César A. Nogueira." (18 characters; Seobility flags anything under 20). Expanded `siteConfig.firstName` from the abbreviated `"César A."` to the full `"César Augusto"` (already used elsewhere as `siteConfig.name` / the `author` meta tag), so the H1 now reads "César Augusto Nogueira." (23 characters). Both the typewriter animation (`hooks/use-typewriter.ts`) and the `aria-label` are computed from the string length dynamically, not hardcoded, so this threads through cleanly with no other code changes.
- **Image missing alt attribute** (listed as a "Tip!"-level nice-to-have) — the mobile hero background portrait (`/portrait-mobile.webp`) had `alt=""`. Its parent `<div>` already carries `aria-hidden`, so assistive tech never reads this image regardless of what `alt` says — giving it real alt text (matching the primary desktop portrait's `alt={siteConfig.name}`) costs nothing for actual accessibility but satisfies automated SEO/alt-attribute checks that don't account for `aria-hidden` ancestors.

## Test plan

- [x] `npm run type-check` passes with no errors
- [x] `npm run lint` passes (only 3 pre-existing warnings in unrelated files, unchanged by this PR)
- [x] Verified via headless browser at desktop (1440px) and mobile (390px) viewports: H1 renders "César Augusto Nogueira." with correct `aria-label`, no text overflow/wrapping regressions, mobile portrait now has `alt="César Augusto Nogueira"`
- [x] Confirmed two pre-existing Next.js dev warnings (a `RecruiterMode` hydration mismatch, an Image `sizes` hint) are unrelated to this change and present before it


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_