### PR TITLE
Link Person/ProfessionalService JSON-LD to up2cloud.tech (entity graph)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -129,6 +129,7 @@ export default function RootLayout({
                     siteConfig.links.linkedin,
                     siteConfig.links.github,
                     siteConfig.links.x,
+                    "https://up2cloud.tech/about/",
                   ],
                   worksFor: { "@id": `${siteConfig.url}/#organization` },
                   address: {
@@ -166,6 +167,7 @@ export default function RootLayout({
                   email: `mailto:${siteConfig.links.email}`,
                   telephone: siteConfig.links.phone,
                   founder: { "@id": `${siteConfig.url}/#person` },
+                  sameAs: ["https://up2cloud.tech"],
                   areaServed: "Worldwide",
                   priceRange: "$$",
                   knowsAbout: siteConfig.knowsAbout,


### PR DESCRIPTION
## Summary

Companion to [up2cloud/up2cloud.github.io#32](https://github.com/UP2CLOUD/up2cloud.github.io/pull/32) (merged), part of a broader SEO audit pass.

This site already visibly links to `up2cloud.tech` (nav/footer), but the JSON-LD `@graph` in `app/layout.tsx` didn't reflect that relationship — the `Person` node's `sameAs` only listed LinkedIn/GitHub/X, and the `ProfessionalService` node had no link to the actual `up2cloud.tech` domain at all, even though it represents the same consulting entity under a different domain.

up2cloud.tech's `/about/` page now links back here (its own `Person` schema's `sameAs` includes `https://cesarnogueira.tech`, added in the linked PR). This change makes it bidirectional:

- `Person.sameAs` gains `https://up2cloud.tech/about/`
- `ProfessionalService.sameAs` gains `https://up2cloud.tech`

Net effect: Google's entity graph can consolidate "César Nogueira" / "UP2CLOUD" as one connected entity across both properties instead of treating them as unrelated, which matters for both personal-brand searches and company searches.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes (only 3 pre-existing warnings in unrelated files)
- [x] Ran the dev server and fetched the rendered homepage HTML, parsed the JSON-LD `@graph`, confirmed both `sameAs` arrays now include the up2cloud.tech URLs


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Updated the site’s structured metadata with additional business and profile references to improve how the site is represented in search and sharing contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->