### PR TITLE
Add /case-studies — the site's biggest indexable-content gap

### DIFF
--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { siteConfig, projects } from "@/lib/site-config";
+import { CaseStudyHeader } from "@/components/case-study-header";
+import { SiteFooter } from "@/components/site-footer";
+import { CaseStudyBody } from "@/components/case-study-body";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return projects.map((p) => ({ slug: p.id }));
+}
+
+function getProject(slug: string) {
+  return projects.find((p) => p.id === slug);
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const project = getProject(slug);
+  if (!project) return {};
+
+  const title = `${project.title} — Case Study`;
+  const description = `${project.outcome} Real ${project.category.toLowerCase()} engagement for ${project.client}, delivered by ${siteConfig.name}.`;
+  const url = `${siteConfig.url}/case-studies/${project.id}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      type: "article",
+      url,
+      title: `${title} · ${siteConfig.name}`,
+      description,
+      images: [{ url: "/opengraph-image.png", width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${title} · ${siteConfig.name}`,
+      description,
+      images: [{ url: "/opengraph-image.png", alt: title }],
+    },
+  };
+}
+
+export default async function CaseStudyPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const project = getProject(slug);
+  if (!project) notFound();
+
+  const url = `${siteConfig.url}/case-studies/${project.id}`;
+  const publishedDate = "2026-07-21";
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Article",
+        "@id": `${url}#article`,
+        headline: `${project.title} — Case Study`,
+        description: project.outcome,
+        url,
+        datePublished: publishedDate,
+        dateModified: publishedDate,
+        author: { "@id": `${siteConfig.url}/#person` },
+        publisher: { "@id": `${siteConfig.url}/#organization` },
+        about: project.category,
+        mainEntityOfPage: url,
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "Home", item: siteConfig.url },
+          { "@type": "ListItem", position: 2, name: "Case Studies", item: `${siteConfig.url}/case-studies` },
+          { "@type": "ListItem", position: 3, name: project.title, item: url },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <CaseStudyHeader />
+      <main className="mx-auto max-w-3xl px-6 py-20 lg:py-28">
+        <nav aria-label="Breadcrumb" className="mb-8 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+          <Link href="/" className="transition-colors hover:text-[var(--color-fg)]">Home</Link>
+          <span className="mx-2">/</span>
+          <Link href="/case-studies" className="transition-colors hover:text-[var(--color-fg)]">Case Studies</Link>
+        </nav>
+        <CaseStudyBody project={project} />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import { siteConfig, projects } from "@/lib/site-config";
+import { CaseStudyHeader } from "@/components/case-study-header";
+import { SiteFooter } from "@/components/site-footer";
+import { CaseStudiesIndexBody } from "@/components/case-studies-index-body";
+
+const title = "Case Studies";
+const description =
+  "Real cloud, FinOps, and platform engineering engagements — FinOps automation, big data platforms, and regulated multi-cloud banking infrastructure — delivered by César Nogueira.";
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: { canonical: `${siteConfig.url}/case-studies` },
+  openGraph: {
+    type: "website",
+    url: `${siteConfig.url}/case-studies`,
+    title: `${title} · ${siteConfig.name}`,
+    description,
+    images: [{ url: "/opengraph-image.png", width: 1200, height: 630, alt: title }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${title} · ${siteConfig.name}`,
+    description,
+    images: [{ url: "/opengraph-image.png", alt: title }],
+  },
+};
+
+export default function CaseStudiesIndexPage() {
+  const url = `${siteConfig.url}/case-studies`;
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "CollectionPage",
+        "@id": `${url}#collection`,
+        url,
+        name: title,
+        description,
+        isPartOf: { "@id": `${siteConfig.url}/#website` },
+        about: { "@id": `${siteConfig.url}/#person` },
+        hasPart: projects.map((p) => ({
+          "@type": "Article",
+          "@id": `${siteConfig.url}/case-studies/${p.id}#article`,
+          url: `${siteConfig.url}/case-studies/${p.id}`,
+          headline: `${p.title} — Case Study`,
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "Home", item: siteConfig.url },
+          { "@type": "ListItem", position: 2, name: "Case Studies", item: url },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <CaseStudyHeader />
+      <main className="mx-auto max-w-3xl px-6 py-20 lg:py-28">
+        <h1 className="font-display text-[clamp(2rem,4vw+0.5rem,3.25rem)] leading-[1.1] text-[var(--color-fg)] [text-wrap:balance]">
+          {title}
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-relaxed text-[var(--color-fg-muted)] sm:text-[17px]">
+          Real engagements, real numbers — the outcomes behind the résumé.
+        </p>
+        <CaseStudiesIndexBody />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import dynamic from "next/dynamic";
 import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/site-footer";
 import { IntroSequence } from "@/components/hero/intro-sequence";
 import { IdentityConsole } from "@/components/hero/identity-console";
 import { Story } from "@/components/sections/story";
@@ -9,8 +10,6 @@ import { Trust } from "@/components/sections/trust";
 import { CapabilityMatrix } from "@/components/sections/capability-matrix";
 import { Certifications } from "@/components/sections/certifications";
 import { Testimonials } from "@/components/sections/testimonials";
-import { MotionToggle } from "@/components/motion-toggle";
-import { siteConfig } from "@/lib/site-config";
 
 // Decorative -z-10 canvas background. The component gates its canvas-vs-static
 // render on a mount flag so SSR and first client paint agree (no hydration
@@ -61,41 +60,7 @@ export default function Home() {
         <ContactConsole />
       </main>
 
-      <footer className="border-t border-[var(--color-hairline)] px-6 py-10">
-        <div className="mx-auto flex max-w-5xl flex-col gap-4">
-          <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-            <p className="font-ui text-[13px] text-[var(--color-fg-subtle)]">
-              &copy; {new Date().getFullYear()} {siteConfig.name} &middot;{" "}
-              <a
-                href="https://up2cloud.tech"
-                target="_blank"
-                rel="noreferrer"
-                className="transition-colors hover:text-[var(--color-fg)]"
-              >
-                {siteConfig.company}
-              </a>
-            </p>
-            <div className="flex items-center gap-4">
-              <a href={siteConfig.links.linkedin} target="_blank" rel="noreferrer" aria-label="LinkedIn" className="p-2 text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
-                </svg>
-              </a>
-              <a href={siteConfig.links.github} target="_blank" rel="noreferrer" aria-label="GitHub" className="p-2 text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]">
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                  <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-                </svg>
-              </a>
-              <a href={siteConfig.links.x} target="_blank" rel="noreferrer" aria-label="X (Twitter)" className="p-2 text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
-                  <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-                </svg>
-              </a>
-              <MotionToggle />
-            </div>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
 
       <CommandPalette />
       <RecruiterMode />

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,28 +1,47 @@
 import type { MetadataRoute } from "next";
-import { siteConfig } from "@/lib/site-config";
+import { siteConfig, projects } from "@/lib/site-config";
 
 export const dynamic = "force-static";
 
+// i18n is a client-side toggle, not per-locale routing, so every page only
+// ever serves one real URL — only "en" and "x-default" are listed per page,
+// each pointing at *that page's own* URL, matching app/layout.tsx's
+// metadata.alternates. Repeating the same URL under pt-BR/es/fr/zh hreflang
+// entries (or pointing every page's alternate at the homepage) reads to
+// crawlers as duplicate/misleading alternates, so don't do either here.
+function selfLanguages(url: string) {
+  return { en: url, "x-default": url };
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = siteConfig.url;
-  const lastModified = new Date("2026-07-09");
+  const homeLastModified = new Date("2026-07-09");
+  const caseStudiesLastModified = new Date("2026-07-21");
 
   return [
     {
       url: base,
-      lastModified,
+      lastModified: homeLastModified,
       changeFrequency: "monthly",
       priority: 1,
-      alternates: {
-        languages: {
-          "en": base,
-          "pt-BR": base,
-          "es": base,
-          "fr": base,
-          "zh": base,
-          "x-default": base,
-        },
-      },
+      alternates: { languages: selfLanguages(base) },
     },
+    {
+      url: `${base}/case-studies`,
+      lastModified: caseStudiesLastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+      alternates: { languages: selfLanguages(`${base}/case-studies`) },
+    },
+    ...projects.map((p) => {
+      const url = `${base}/case-studies/${p.id}`;
+      return {
+        url,
+        lastModified: caseStudiesLastModified,
+        changeFrequency: "yearly" as const,
+        priority: 0.7,
+        alternates: { languages: selfLanguages(url) },
+      };
+    }),
   ];
 }

--- a/components/case-studies-index-body.tsx
+++ b/components/case-studies-index-body.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { m, useReducedMotion } from "motion/react";
+import { Reveal } from "@/components/reveal";
+import { projects } from "@/lib/site-config";
+import { useI18n } from "@/lib/i18n";
+import { cardHover } from "@/lib/motion";
+
+export function CaseStudiesIndexBody() {
+  const { t } = useI18n();
+  const reduce = useReducedMotion();
+
+  return (
+    <div className="mt-12 space-y-6">
+      {projects.map((p, i) => {
+        const tr = t.projects[p.id];
+        const category = tr?.category ?? p.category;
+        const title = tr?.title ?? p.title;
+        const client = tr?.client ?? p.client;
+        const outcome = tr?.outcome ?? p.outcome;
+        const metricLabel = tr?.metricLabel ?? p.metricLabel;
+
+        return (
+          <Reveal key={p.id} delay={i * 0.05}>
+            <Link href={`/case-studies/${p.id}`} className="block">
+              <m.article
+                whileHover={reduce ? undefined : cardHover}
+                className="panel grid gap-6 rounded-xl p-6 transition-colors hover:border-[var(--color-hairline-strong)] sm:grid-cols-[auto_1fr] sm:items-center sm:p-8"
+              >
+                <div className="text-left sm:text-center">
+                  <p className="font-display text-4xl text-[var(--color-fg)]">{p.metric}</p>
+                  <p className="mt-1 font-mono text-[10px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+                    {metricLabel}
+                  </p>
+                </div>
+                <div>
+                  <span className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-blue)]">
+                    {category}
+                  </span>
+                  <h2 className="mt-2 text-lg font-medium text-[var(--color-fg)]">{title}</h2>
+                  <p className="mt-1 font-mono text-xs text-[var(--color-fg-subtle)]">{client}</p>
+                  <p className="mt-3 text-[15px] leading-relaxed text-[var(--color-fg-muted)]">{outcome}</p>
+                  <span className="mt-3 inline-block text-sm font-medium text-[var(--color-blue)]">
+                    Read the full case study →
+                  </span>
+                </div>
+              </m.article>
+            </Link>
+          </Reveal>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/case-study-body.tsx
+++ b/components/case-study-body.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import Link from "next/link";
+import { m, useReducedMotion } from "motion/react";
+import { Reveal } from "@/components/reveal";
+import { projects } from "@/lib/site-config";
+import { useI18n } from "@/lib/i18n";
+
+type Project = (typeof projects)[number];
+
+export function CaseStudyBody({ project: p }: { project: Project }) {
+  const { t } = useI18n();
+  const reduce = useReducedMotion();
+
+  const tr = t.projects[p.id];
+  const category = tr?.category ?? p.category;
+  const title = tr?.title ?? p.title;
+  const client = tr?.client ?? p.client;
+  const problem = tr?.problem ?? p.problem;
+  const architecture = tr?.architecture ?? p.architecture;
+  const scale = tr?.scale ?? p.scale;
+  const impact = tr?.impact ?? p.impact;
+  const outcome = tr?.outcome ?? p.outcome;
+  const lessons = tr?.lessons ?? p.lessons;
+  const metricLabel = tr?.metricLabel ?? p.metricLabel;
+
+  return (
+    <article>
+      <Reveal>
+        <span className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-blue)]">
+          {category}
+        </span>
+        <h1 className="font-display mt-4 text-[clamp(2rem,4vw+0.5rem,3.25rem)] leading-[1.1] text-[var(--color-fg)] [text-wrap:balance]">
+          {title}
+        </h1>
+        <p className="mt-3 font-mono text-[13px] text-[var(--color-fg-subtle)]">
+          {client} · {scale}
+        </p>
+      </Reveal>
+
+      <Reveal delay={0.05}>
+        <div className="mt-10 flex items-baseline gap-4 border-y border-[var(--color-hairline)] py-6">
+          <p className="font-display text-6xl text-[var(--color-fg)]">{p.metric}</p>
+          <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+            {metricLabel}
+          </p>
+        </div>
+      </Reveal>
+
+      <Reveal delay={0.1}>
+        <div className="mt-10 grid gap-8 sm:grid-cols-2">
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+              {t.labels.problem}
+            </p>
+            <p className="mt-2 text-[15px] leading-relaxed text-[var(--color-fg-muted)]">{problem}</p>
+          </div>
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+              {t.labels.architecture}
+            </p>
+            <p className="mt-2 text-[15px] leading-relaxed text-[var(--color-fg-muted)]">{architecture}</p>
+          </div>
+        </div>
+      </Reveal>
+
+      <Reveal delay={0.15}>
+        <div className="mt-10 border-t border-[var(--color-hairline)] pt-6">
+          <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-ok)]">
+            {t.labels.businessResult}
+          </p>
+          <p className="mt-2 text-[15px] leading-relaxed text-[var(--color-fg)]">{outcome}</p>
+          <ul className="mt-4 flex flex-wrap gap-x-6 gap-y-2">
+            {impact.map((it) => (
+              <li key={it} className="flex items-center gap-2 text-sm text-[var(--color-fg-muted)]">
+                <span className="text-[var(--color-ok)]">✓</span>
+                {it}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </Reveal>
+
+      {lessons && (
+        <Reveal delay={0.2}>
+          <div className="mt-10 rounded border border-[var(--color-blue)]/20 bg-[var(--color-blue)]/5 px-5 py-4">
+            <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-blue)]">
+              {t.labels.lessons}
+            </p>
+            <p className="mt-2 text-[15px] leading-relaxed text-[var(--color-fg-muted)] italic [text-wrap:pretty]">
+              {lessons}
+            </p>
+          </div>
+        </Reveal>
+      )}
+
+      <Reveal delay={0.25}>
+        <div className="mt-10 flex flex-wrap gap-x-5 gap-y-1">
+          {p.tech.map((tech) => (
+            <span key={tech} className="font-mono text-[11px] text-[var(--color-fg-subtle)]">
+              {tech}
+            </span>
+          ))}
+        </div>
+      </Reveal>
+
+      <Reveal delay={0.3}>
+        <div className="mt-16 flex flex-col items-start gap-4 border-t border-[var(--color-hairline)] pt-10 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-[15px] text-[var(--color-fg-muted)]">
+            Have a similar problem to solve?
+          </p>
+          <m.div whileTap={reduce ? undefined : { scale: 0.97 }}>
+            <Link
+              href="/#contact"
+              className="inline-flex items-center rounded-md px-6 py-3 text-sm font-medium text-white transition-all hover:opacity-90 hover:-translate-y-px active:translate-y-0"
+              style={{ backgroundColor: "var(--color-button-primary)" }}
+            >
+              Let&apos;s talk
+            </Link>
+          </m.div>
+        </div>
+      </Reveal>
+    </article>
+  );
+}

--- a/components/case-study-header.tsx
+++ b/components/case-study-header.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { LanguageSwitcher } from "@/components/language-switcher";
+import { Logo } from "@/components/logo";
+import { useI18n } from "@/lib/i18n";
+
+/** Simplified header for standalone sub-pages (case studies) — no in-page
+ * scroll-spy nav since those anchors only exist on the homepage. */
+export function CaseStudyHeader() {
+  const { t } = useI18n();
+  return (
+    <header className="sticky top-0 z-40 border-b border-[var(--color-hairline)] bg-[var(--background)]/80 backdrop-blur-md">
+      <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <Link href="/" className="flex items-center gap-2.5 text-[var(--color-fg)]" aria-label={t.palette.home}>
+          <Logo size={26} className="text-[var(--color-blue)]" />
+          <span className="font-display text-sm">César A. Nogueira</span>
+        </Link>
+        <div className="flex items-center gap-3">
+          <Link
+            href="/"
+            className="font-ui text-[13px] text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
+          >
+            ← Back to home
+          </Link>
+          <LanguageSwitcher />
+          <ThemeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/sections/projects.tsx
+++ b/components/sections/projects.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { m, useReducedMotion } from "motion/react";
 import { Section } from "@/components/sections/section";
 import { Reveal } from "@/components/reveal";
@@ -100,6 +101,13 @@ export function Projects() {
                       </span>
                     ))}
                   </div>
+
+                  <Link
+                    href={`/case-studies/${p.id}`}
+                    className="inline-block text-sm font-medium text-[var(--color-blue)] transition-colors hover:opacity-80"
+                  >
+                    Read the full case study →
+                  </Link>
                 </div>
               </m.article>
             </Reveal>

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -1,0 +1,44 @@
+import { siteConfig } from "@/lib/site-config";
+import { MotionToggle } from "@/components/motion-toggle";
+
+/** Shared footer — homepage and standalone sub-pages (case studies) both
+ * use this so the site chrome stays consistent. */
+export function SiteFooter() {
+  return (
+    <footer className="border-t border-[var(--color-hairline)] px-6 py-10">
+      <div className="mx-auto flex max-w-5xl flex-col gap-4">
+        <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+          <p className="font-ui text-[13px] text-[var(--color-fg-subtle)]">
+            &copy; {new Date().getFullYear()} {siteConfig.name} &middot;{" "}
+            <a
+              href="https://up2cloud.tech"
+              target="_blank"
+              rel="noreferrer"
+              className="transition-colors hover:text-[var(--color-fg)]"
+            >
+              {siteConfig.company}
+            </a>
+          </p>
+          <div className="flex items-center gap-4">
+            <a href={siteConfig.links.linkedin} target="_blank" rel="noreferrer" aria-label="LinkedIn" className="p-2 text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+              </svg>
+            </a>
+            <a href={siteConfig.links.github} target="_blank" rel="noreferrer" aria-label="GitHub" className="p-2 text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
+              </svg>
+            </a>
+            <a href={siteConfig.links.x} target="_blank" rel="noreferrer" aria-label="X (Twitter)" className="p-2 text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.748l7.73-8.835L1.254 2.25H8.08l4.253 5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+              </svg>
+            </a>
+            <MotionToggle />
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

The last SEO report on this site scored 92/100 with everything technical fixed — but the real ceiling on "ranking for more searches" isn't a checklist item, it's that **the site is one URL**. `/` can only ever rank for the handful of queries its single page's content covers.

The three "Mission Portfolio" cards on the homepage (FinOps automation, big data platform, multi-cloud banking/aviation) already have complete, real, résumé-grounded case data in `lib/site-config.ts` — problem, architecture, outcome, impact metrics, lessons learned. It just wasn't reachable as its own crawlable, shareable, indexable URL. This PR fixes that.

**New:**
- `/case-studies/[slug]` — one page per project, statically generated (`generateStaticParams`), each with its own title/description/OG/Twitter metadata and `Article` + `BreadcrumbList` JSON-LD. The `Article.author` references the existing `Person` `@id` from the root layout's graph, so it's recognized as the same entity, not a new one.
- `/case-studies` — an index/hub page linking to all three, with `CollectionPage` + `BreadcrumbList` JSON-LD.
- "Read the full case study →" links added to the existing homepage cards.
- `app/sitemap.ts` now includes all 4 new URLs. Building this surfaced a real pre-existing bug: every sitemap entry's hreflang `alternates.languages` was hardcoded to the homepage URL regardless of which page it described — harmless when the sitemap had exactly one URL, wrong now that it has five. Fixed so each entry self-references.

**Refactor:** extracted the homepage's inline `<footer>` into `components/site-footer.tsx` (renamed from the homepage-only naming it would've had) so the new pages share identical site chrome instead of duplicating ~35 lines of markup.

**Content/language note:** all copy is pulled directly from `lib/site-config.ts` — nothing invented. New page-chrome strings (breadcrumb, "read the full case study", back-to-home) are English-only; the case-study body content itself still runs through the existing `t.projects[p.id]` translations, so non-English visitors get translated case-study content inside English-only page furniture. Full i18n coverage for the new chrome felt like reasonable scope for a fast-follow rather than blocking this.

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes (only 3 pre-existing warnings in unrelated files)
- [x] `npm run build` — all three case-study routes prerender as static HTML, confirmed in the build's route table
- [x] Verified `/sitemap.xml` output: 5 URLs, each with a correctly self-referencing hreflang alternate (not the earlier bug)
- [x] Verified JSON-LD on a case-study page: both the root `Person`/`WebSite`/`ProfessionalService` graph and the page's own `Article`/`BreadcrumbList` graph parse as valid JSON, `Article.author` correctly `@id`-references the existing `Person` node
- [x] Screenshotted all 3 case-study pages, the index page, and the homepage's Work section + footer (post-extraction) — no visual regressions, everything on-brand


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_