### PR TITLE
Perf + content: fix llms.txt and remove wasteful portrait preload

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -97,8 +97,6 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      {/* LCP preload — React 19 hoists this to <head> automatically */}
-      <link rel="preload" as="image" href="/portrait.webp" fetchPriority="high" />
       <body
         className={`${geist.variable} ${geistMono.variable} ${interTight.variable} ${hanken.variable} tracking-tight-body antialiased`}
         suppressHydrationWarning

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,14 +6,16 @@
 ## Pages
 
 - [Home](https://cesarnogueira.tech): Overview, selected work, stack, and contact.
+- [Case Studies](https://cesarnogueira.tech/case-studies): Real cloud, FinOps, and platform engineering engagements with outcomes.
 
 ## About
 
 Cesar Augusto Nogueira is a principal-level consultant specializing in cloud
-architecture (AWS, Azure), platform engineering, Kubernetes, Terraform, DevOps,
-and FinOps. Available for consulting engagements worldwide.
+architecture (GCP, AWS, Azure), platform engineering, Kubernetes, Terraform, DevOps,
+and FinOps. Available for consulting engagements worldwide via UP2CLOUD.
 
 ## Optional
 
-- [LinkedIn](https://www.linkedin.com/in/cesar-nogueira/)
+- [LinkedIn](https://www.linkedin.com/in/cesarnog/)
 - [GitHub](https://github.com/cesarnog)
+- [UP2CLOUD](https://up2cloud.tech)


### PR DESCRIPTION
## Summary

- **Fix `llms.txt`**: LinkedIn URL was `/cesar-nogueira/` (404); corrected to `/cesarnog/`. Added case studies page and UP2CLOUD link. Clarified cloud platform priority (GCP listed first, matching actual expertise).
- **Remove wasteful layout preload**: `app/layout.tsx` had a `<link rel="preload" href="/portrait.webp">` that downloaded the raw 504 KB file on every page (including case studies). Next.js `<Image priority>` already generates the correct preload for the `/_next/image` optimized URL, so the manual hint was redundant and added ~504 KB of unnecessary bandwidth per page load.

## Test plan

- [ ] `npm run build` passes
- [ ] Type-check & Lint CI green
- [ ] Verify `/llms.txt` is accessible and LinkedIn URL resolves
- [ ] Confirm hero portrait still loads correctly on home page (LCP unaffected — Next.js Image handles preload)
- [ ] Check Network tab: `/portrait.webp` raw file should no longer appear as a preload on case study pages

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_