### PR TITLE
seo: extend AI training crawler blocklist in robots.txt

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -20,6 +20,10 @@ export default function robots(): MetadataRoute.Robots {
       { userAgent: "omgili", disallow: "/" },
       { userAgent: "Diffbot", disallow: "/" },
       { userAgent: "Meta-ExternalAgent", disallow: "/" },
+      { userAgent: "Google-Extended", disallow: "/" },
+      { userAgent: "Amazonbot", disallow: "/" },
+      { userAgent: "PerplexityBot", disallow: "/" },
+      { userAgent: "Applebot-Extended", disallow: "/" },
     ],
     sitemap: `${siteConfig.url}/sitemap.xml`,
   };


### PR DESCRIPTION
## Summary

- Adds `Google-Extended` (Google Gemini/Bard training opt-out) — the most important missing entry
- Adds `Amazonbot` (Amazon AI training crawler)
- Adds `PerplexityBot` (Perplexity AI crawler)
- Adds `Applebot-Extended` (Apple AI training opt-out)

The previous list already blocked GPTBot, ClaudeBot, CCBot, Bytespider, cohere-ai, Diffbot, Meta-ExternalAgent, ChatGPT-User, and Claude-Web. These four fill the gaps identified by comparing against the up2cloud.tech site's blocklist.

## Why this matters

`Google-Extended` is the official opt-out for Gemini AI training — without it, Google can use the portfolio content to train its AI models even while Googlebot indexes it normally. `Amazonbot` serves the same role for Amazon's AI stack.

## Test plan

- [ ] Build passes (`npm run type-check` + `npm run lint`)
- [ ] `GET /robots.txt` on preview deployment lists all new user-agents with `Disallow: /`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_