### PR TITLE
security: CSP/HSTS headers, contact form validation, PWA manifest

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -45,7 +45,9 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
     question = String(body?.question || "").slice(0, 600);
-    lang = String(body?.lang || "en").slice(0, 5);
+    const rawLang = String(body?.lang || "en").slice(0, 5);
+    const ALLOWED_LANGS = new Set(["en", "pt", "es", "fr", "zh"]);
+    lang = ALLOWED_LANGS.has(rawLang) ? rawLang : "en";
   } catch {
     return NextResponse.json({ error: "Bad request" }, { status: 400 });
   }

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -30,6 +30,13 @@ export async function POST(req: NextRequest) {
   const { name, email, subject, message } = body;
   if (!name || !email || !message) return NextResponse.json({ error: "Missing fields" }, { status: 400 });
 
+  if (typeof name !== "string" || name.length > 100) return NextResponse.json({ error: "Invalid name" }, { status: 400 });
+  if (typeof email !== "string" || email.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+  if (subject !== undefined && (typeof subject !== "string" || subject.length > 200))
+    return NextResponse.json({ error: "Invalid subject" }, { status: 400 });
+  if (typeof message !== "string" || message.length > 5000) return NextResponse.json({ error: "Invalid message" }, { status: 400 });
+
   const sentAt = new Date().toLocaleString("en-GB", {
     timeZone: "Europe/Lisbon",
     day: "2-digit", month: "short", year: "numeric",

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "César Nogueira · Principal Cloud Architect",
+    short_name: "César Nogueira",
+    description: "Principal Cloud Architect & FinOps Consultant — UP2CLOUD",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#08090c",
+    theme_color: "#08090c",
+    icons: [
+      { src: "/apple-icon.png", sizes: "180x180", type: "image/png" },
+    ],
+  };
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -7,7 +7,7 @@ export const dynamic = "force-static";
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
-      { userAgent: "*", allow: "/" },
+      { userAgent: "*", allow: "/", disallow: ["/api/"] },
       // Block AI training crawlers from scraping content without permission
       { userAgent: "GPTBot", disallow: "/" },
       { userAgent: "ChatGPT-User", disallow: "/" },

--- a/vercel.json
+++ b/vercel.json
@@ -5,10 +5,14 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Frame-Options",        "value": "SAMEORIGIN" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy",        "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy",     "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" }
+        { "key": "X-Frame-Options",                    "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options",             "value": "nosniff" },
+        { "key": "Referrer-Policy",                    "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy",                 "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
+        { "key": "Strict-Transport-Security",          "value": "max-age=63072000; includeSubDomains; preload" },
+        { "key": "Cross-Origin-Opener-Policy",         "value": "same-origin-allow-popups" },
+        { "key": "Cross-Origin-Resource-Policy",       "value": "same-origin" },
+        { "key": "Content-Security-Policy",            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.hotjar.com https://script.hotjar.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://va.vercel-scripts.com https://in.hotjar.com https://vc.hotjar.io https://metrics.hotjar.io https://content.hotjar.io https://api.hotjar.com https://www.hotjar.com wss://ws.hotjar.com https://googleads.g.doubleclick.net https://www.googleadservices.com; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; upgrade-insecure-requests;" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- **`vercel.json` — security headers**: Added four missing headers to all routes:
  - `Content-Security-Policy`: covers GTM, Hotjar, Google Fonts, Vercel Analytics, Google Ads; `'unsafe-inline'` required for Next.js hydration scripts and JSON-LD blocks.
  - `Strict-Transport-Security`: `max-age=63072000; includeSubDomains; preload` (2-year window, eligible for HSTS preload list).
  - `Cross-Origin-Opener-Policy: same-origin-allow-popups` — allows OAuth/payment popups while blocking cross-origin window access.
  - `Cross-Origin-Resource-Policy: same-origin` — prevents cross-origin hotlinking of site resources.

- **`app/api/contact/route.ts` — input validation**: Added email format regex (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`) and field-length caps (`name ≤ 100`, `email ≤ 254`, `subject ≤ 200`, `message ≤ 5000`) before constructing the HTML email. The `esc()` sanitization and rate limiting were already correct.

- **`app/api/ask/route.ts` — lang allowlist**: `lang` was sliced to 5 chars but never validated against the actual supported languages. Now explicitly checks against `Set(["en","pt","es","fr","zh"])` and falls back to `"en"` for anything else.

- **`app/robots.ts` — disallow `/api/`**: Added `disallow: ["/api/"]` to the general-crawlers rule. The `/api/ask` and `/api/contact` routes are POST-only serverless handlers — GET crawling them returns nothing useful.

- **`app/manifest.ts` — PWA Web App Manifest**: Created the Next.js App Router `manifest.ts` convention file. Next.js auto-links this as `<link rel="manifest" href="/manifest.webmanifest">` on every page. Fixes the missing PWA manifest (Lighthouse, Android Chrome installability).

## Test plan

- [ ] `npm run type-check` — passes (verified locally before push)
- [ ] `npm run lint` — no new errors
- [ ] Verify security headers appear on deployed site (e.g. via `curl -I https://cesarnogueira.tech`)
- [ ] Confirm contact form still accepts valid submissions
- [ ] Confirm contact form rejects `email: "not-an-email"` with 400
- [ ] Check `/manifest.webmanifest` is served correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app metadata and standalone display support for improved installation and mobile app experiences.
  * Added an Apple touch icon and configured application colors and start behavior.

* **Bug Fixes**
  * Improved language handling by defaulting unsupported or invalid selections to English.
  * Added validation for contact form names, email addresses, subjects, and messages.

* **Security**
  * Strengthened browser security protections and prevented API routes from being indexed by search engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->