### PR TITLE
fix: align X-Frame-Options with CSP frame-ancestors, add va.vercel-scripts.com to script-src

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,14 +5,14 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Frame-Options",                    "value": "SAMEORIGIN" },
+        { "key": "X-Frame-Options",                    "value": "DENY" },
         { "key": "X-Content-Type-Options",             "value": "nosniff" },
         { "key": "Referrer-Policy",                    "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy",                 "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },
         { "key": "Strict-Transport-Security",          "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "Cross-Origin-Opener-Policy",         "value": "same-origin-allow-popups" },
         { "key": "Cross-Origin-Resource-Policy",       "value": "same-origin" },
-        { "key": "Content-Security-Policy",            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.hotjar.com https://script.hotjar.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://va.vercel-scripts.com https://in.hotjar.com https://vc.hotjar.io https://metrics.hotjar.io https://content.hotjar.io https://api.hotjar.com https://www.hotjar.com wss://ws.hotjar.com https://googleads.g.doubleclick.net https://www.googleadservices.com; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; upgrade-insecure-requests;" }
+        { "key": "Content-Security-Policy",            "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://static.hotjar.com https://script.hotjar.com https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://vitals.vercel-insights.com https://va.vercel-scripts.com https://in.hotjar.com https://vc.hotjar.io https://metrics.hotjar.io https://content.hotjar.io https://api.hotjar.com https://www.hotjar.com wss://ws.hotjar.com https://googleads.g.doubleclick.net https://www.googleadservices.com; frame-src 'none'; frame-ancestors 'none'; object-src 'none'; upgrade-insecure-requests;" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

Two small consistency fixes to `vercel.json` following a CSP audit of the headers added in PR #49.

- **`X-Frame-Options: SAMEORIGIN` → `DENY`**: PR #49 added `frame-ancestors 'none'` to the CSP, which forbids all framing. `X-Frame-Options: SAMEORIGIN` contradicts this by permitting same-origin iframing. Modern browsers honour `frame-ancestors` and ignore `X-Frame-Options` when both are present, so `'none'` wins for them. However, older browsers that only implement `X-Frame-Options` would see `SAMEORIGIN` and allow same-origin embedding. Changing to `DENY` makes both mechanisms consistent.

- **`va.vercel-scripts.com` added to `script-src`**: The domain is already listed in `connect-src` (showing intent), but was missing from `script-src`. Vercel Analytics currently loads via a same-origin proxy on Vercel's infrastructure (`/_vercel/insights/script.js`), so it works today without the explicit allowlist entry. Adding it makes the policy self-documenting and robust if Vercel's proxy path ever changes.

## Test plan

- [ ] `npm run type-check` — passes (verified before push)
- [ ] Verify no framing-related regressions on the live site
- [ ] Confirm Vercel Analytics still records visits after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_