### PR TITLE
fix: custom 404 page, JSON-LD email format, X-XSS-Protection header

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -119,7 +119,7 @@ export default function RootLayout({
                   name: siteConfig.name,
                   alternateName: "Cesar Nogueira",
                   url: siteConfig.url,
-                  email: `mailto:${siteConfig.links.email}`,
+                  email: siteConfig.links.email,
                   telephone: siteConfig.links.phone,
                   jobTitle: "Principal Cloud Architect",
                   description: siteConfig.description,
@@ -164,7 +164,7 @@ export default function RootLayout({
                   description:
                     "Independent Principal Cloud Architect and FinOps consultancy — multi-cloud architecture, Platform Engineering, DevOps and cloud cost optimization for enterprise teams worldwide.",
                   image: `${siteConfig.url}/opengraph-image.png`,
-                  email: `mailto:${siteConfig.links.email}`,
+                  email: siteConfig.links.email,
                   telephone: siteConfig.links.phone,
                   founder: { "@id": `${siteConfig.url}/#person` },
                   sameAs: ["https://up2cloud.tech"],

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
+import { Logo } from "@/components/logo";
+
+export const metadata = {
+  title: "404 — Page Not Found",
+};
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="flex items-center px-6 py-5 border-b border-[var(--color-hairline)]">
+        <Link href="/" aria-label="Return to home">
+          <Logo />
+        </Link>
+      </header>
+
+      <main className="flex flex-1 flex-col items-center justify-center gap-6 px-6 py-24 text-center">
+        <p className="font-mono text-5xl font-bold text-[var(--color-blue)] tabular-nums">
+          404
+        </p>
+        <h1 className="font-heading text-2xl font-semibold text-[var(--color-fg)]">
+          Page not found
+        </h1>
+        <p className="max-w-sm text-[var(--color-fg-subtle)] text-sm leading-relaxed">
+          This URL doesn&apos;t exist. It may have been moved, deleted, or you may have followed a broken link.
+        </p>
+        <Link
+          href="/"
+          className="mt-2 inline-flex items-center gap-2 rounded-lg bg-[var(--color-blue)] px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-blue)]"
+        >
+          ← Return home
+        </Link>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,7 @@
       "source": "/(.*)",
       "headers": [
         { "key": "X-Frame-Options",                    "value": "DENY" },
+        { "key": "X-XSS-Protection",                   "value": "1; mode=block" },
         { "key": "X-Content-Type-Options",             "value": "nosniff" },
         { "key": "Referrer-Policy",                    "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy",                 "value": "camera=(), microphone=(), geolocation=(), interest-cohort=()" },


### PR DESCRIPTION
## Summary

Three independent polish fixes identified by a full site audit.

### UX / Brand (Medium)
**`app/not-found.tsx` — custom 404 page**
Next.js's default 404 is a plain white page with no navigation, breaking the dark-theme brand experience on any mistyped URL. The new page:
- Uses the CN logo mark, `SiteFooter`, and the CSS-var design token system (`--color-blue`, `--color-fg`, `--color-fg-subtle`, `--color-hairline`)
- Has a prominent "← Return home" CTA styled with the brand blue
- Is a server component — no client-side JS required
- Includes a `metadata.title` so the browser tab shows "404 — Page Not Found"

### SEO / Structured Data (Low)
**`app/layout.tsx` — fix JSON-LD `email` field format**
Both the `Person` and `ProfessionalService` nodes in the `@graph` were emitting `email: "mailto:email@example.com"`. Schema.org's `email` property expects a plain email address string, not a URI. Google's Structured Data documentation examples always use the bare address. Fixed both occurrences.

### Security (Low)
**`vercel.json` — add `X-XSS-Protection: 1; mode=block`**
This header is deprecated in modern browsers (the CSP already handles XSS mitigation), but security scanners (SecurityHeaders.com, OWASP ZAP) and some compliance tools still flag its absence. Adding it costs nothing and improves scanner scores.

## Test plan

- [ ] Visit `/404` or any invalid path — confirm branded page renders (dark background, CN logo, "← Return home" button)
- [ ] Validate JSON-LD with Google Rich Results Test — confirm no `email` format warnings
- [ ] Check response headers in browser DevTools — confirm `X-XSS-Protection: 1; mode=block` is present
- [ ] Type-check passes (`npm run type-check`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_