### PR TITLE
feat: add 192×192 and 512×512 PWA icons for Chrome installability

### DIFF
--- a/app/icon0.tsx
+++ b/app/icon0.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from "next/og";
+
+export const dynamic = "force-static";
+export const size = { width: 192, height: 192 };
+export const contentType = "image/png";
+
+export default async function Icon192() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#08090c",
+        }}
+      >
+        <div style={{ display: "flex", fontSize: 112, fontWeight: 900, color: "#3b82f6", letterSpacing: "-0.06em" }}>
+          CN
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/icon1.tsx
+++ b/app/icon1.tsx
@@ -1,0 +1,27 @@
+import { ImageResponse } from "next/og";
+
+export const dynamic = "force-static";
+export const size = { width: 512, height: 512 };
+export const contentType = "image/png";
+
+export default async function Icon512() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: "#08090c",
+        }}
+      >
+        <div style={{ display: "flex", fontSize: 296, fontWeight: 900, color: "#3b82f6", letterSpacing: "-0.06em" }}>
+          CN
+        </div>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -10,7 +10,11 @@ export default function manifest(): MetadataRoute.Manifest {
     background_color: "#08090c",
     theme_color: "#08090c",
     icons: [
+      { src: "/icon.svg",       sizes: "any",     type: "image/svg+xml" },
       { src: "/apple-icon.png", sizes: "180x180", type: "image/png" },
+      { src: "/icon0.png",      sizes: "192x192", type: "image/png", purpose: "any" },
+      { src: "/icon1.png",      sizes: "512x512", type: "image/png", purpose: "any" },
+      { src: "/icon1.png",      sizes: "512x512", type: "image/png", purpose: "maskable" },
     ],
   };
 }


### PR DESCRIPTION
## Summary

Chrome requires a 192×192 **and** a 512×512 PNG icon in the web app manifest to offer the PWA install prompt. Without them, Lighthouse reports the manifest as not installable.

- **`app/icon0.tsx`** (new): Next.js `ImageResponse` generator for the 192×192 PNG served at `/icon0.png` — same CN monogram design as `apple-icon.tsx`
- **`app/icon1.tsx`** (new): same generator at 512×512 for `/icon1.png`
- **`app/manifest.ts`**: adds four icon entries to the manifest:
  - `/icon.svg` — `sizes: "any"` SVG (already existed, now registered)
  - `/apple-icon.png` — 180×180 Apple touch icon (existing)
  - `/icon0.png` — 192×192 `purpose: "any"` (new)
  - `/icon1.png` — 512×512 `purpose: "any"` + a second `purpose: "maskable"` entry for Android adaptive icon support (new)

## Test plan

- [ ] Type-check & Lint pass
- [ ] Lighthouse PWA audit shows installable (green checkmark on manifest icons)
- [ ] Chrome DevTools Application → Manifest shows all icon sizes

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_