### PR TITLE
chore: remove 4 ESLint no-unused-vars warnings

### DIFF
--- a/components/chatbot/assistant.tsx
+++ b/components/chatbot/assistant.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
-import { faq, siteConfig } from "@/lib/site-config";
+import { faq } from "@/lib/site-config";
 import { useI18n } from "@/lib/i18n";
-import { AVATAR_SRC } from "@/lib/images";
 import { EASE, DUR } from "@/lib/motion";
 
 // ─── Types ────────────────────────────────────────────────────────────────────

--- a/components/recruiter-mode.tsx
+++ b/components/recruiter-mode.tsx
@@ -338,12 +338,6 @@ export function RecruiterMode() {
     localStorage.setItem("recruiter-mode", "1");
     setRecruiterOn(true);
   };
-  const disableRecruiter = () => {
-    document.documentElement.removeAttribute("data-recruiter");
-    localStorage.removeItem("recruiter-mode");
-    setRecruiterOn(false);
-  };
-
   const openPanel = () => { enableRecruiter(); setPanelOpen(true); };
   const closePanel = () => { setPanelOpen(false); };
 

--- a/components/sections/cloud-galaxy.tsx
+++ b/components/sections/cloud-galaxy.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-// inView state kept for future use but ForceGalaxy is now instant SVG
+import { useState } from "react";
 import { Section } from "@/components/sections/section";
 import { ForceGalaxy } from "@/components/background/force-graph";
 import { galaxy, galaxyGroups } from "@/lib/site-config";
@@ -16,19 +15,6 @@ const ACCENT: Record<string, string> = {
 export function CloudGalaxy() {
   const { t } = useI18n();
   const [active, setActive] = useState<string | null>(null);
-  const [inView, setInView] = useState(false);
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = panelRef.current;
-    if (!el) return;
-    const io = new IntersectionObserver(
-      ([entry]) => { if (entry.isIntersecting) setInView(true); },
-      { rootMargin: "400px" },
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  }, []);
 
   return (
     <Section
@@ -38,7 +24,6 @@ export function CloudGalaxy() {
     >
       <div className="grid gap-6 lg:grid-cols-[1.4fr_1fr]">
         <div
-          ref={panelRef}
           data-recruiter-dim
           className="panel relative min-h-[360px] overflow-hidden rounded-lg lg:min-h-[420px]"
         >


### PR DESCRIPTION
## Summary

Cleans up four `@typescript-eslint/no-unused-vars` warnings that appear in `npm run lint` output. No behaviour change — dead code removal only.

- **`components/chatbot/assistant.tsx`**: remove unused `siteConfig` and `AVATAR_SRC` imports
- **`components/recruiter-mode.tsx`**: remove `disableRecruiter()` function — defined but never called (closing the panel doesn't disable recruiter mode; confirmed intentional)
- **`components/sections/cloud-galaxy.tsx`**: remove `inView` state, `panelRef` ref, and the now-inert `IntersectionObserver` `useEffect` — `ForceGalaxy` renders instantly as SVG and no longer needs lazy-load gating; the stale comment explaining this is also removed

## Test plan

- [ ] `npm run lint` → 0 problems
- [ ] `npm run type-check` → no errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal code and imports.
  * Simplified recruiter mode handling while preserving its activation behavior.
  * Simplified the cloud galaxy display by removing unnecessary viewport detection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->