### PR TITLE
fix(chatbot): PT-BR responses revert to English after first FAQ answer

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -32,7 +32,10 @@ const LANG_NAMES: Record<string, string> = { en: "English", pt: "Portuguese", es
 
 function buildSystemPrompt(lang: string): string {
   const langName = LANG_NAMES[lang] || "English";
-  return `You are the AI Career Assistant for Principal Cloud Architect Cesar Augusto Nogueira. Your audience is recruiters, CTOs, VPs of Engineering, Platform Directors, Heads of Cloud and Founders evaluating Cesar for a role or consulting engagement. Act as an expert representative of the candidate: answer concisely (2-4 sentences), professionally and in the third person, and always lead with seniority, scale, business impact, leadership or availability where relevant. Use ONLY the facts below. If asked something unrelated or unknown, briefly steer back to Cesar's professional fit and suggest emailing him. Never invent employers, certifications or numbers. IMPORTANT: Always reply in ${langName}, regardless of the language used in the question.\n\nFACTS:\n${KNOWLEDGE_BASE}`;
+  const langRule = lang === "en"
+    ? "Always reply in English."
+    : `MANDATORY LANGUAGE RULE: You MUST reply exclusively in ${langName}. Never switch to English, even for technical terms — keep all explanatory prose in ${langName}. If you reply in English you are violating this rule.`;
+  return `You are the AI Career Assistant for Principal Cloud Architect Cesar Augusto Nogueira. Your audience is recruiters, CTOs, VPs of Engineering, Platform Directors, Heads of Cloud and Founders evaluating Cesar for a role or consulting engagement. Act as an expert representative of the candidate: answer concisely (2-4 sentences), professionally and in the third person, and always lead with seniority, scale, business impact, leadership or availability where relevant. Use ONLY the facts below. If asked something unrelated or unknown, briefly steer back to Cesar's professional fit and suggest emailing him. Never invent employers, certifications or numbers. ${langRule}\n\nFACTS:\n${KNOWLEDGE_BASE}`;
 }
 
 export async function POST(req: NextRequest) {

--- a/components/chatbot/assistant.tsx
+++ b/components/chatbot/assistant.tsx
@@ -33,6 +33,11 @@ export function Assistant() {
   const reduce = useReducedMotion();
   const { t, lang } = useI18n();
 
+  // Always-current lang ref so the fetch uses the live locale even if the
+  // memoized `ask` callback was created in an earlier render.
+  const langRef = useRef(lang);
+  useEffect(() => { langRef.current = lang; }, [lang]);
+
   const getFollowUps = (answer: string): string[] => {
     const lower = answer.toLowerCase();
     const fu = t.assistantFollowUps;
@@ -157,7 +162,7 @@ export function Assistant() {
         const res = await fetch("/api/ask", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ question: q, lang }),
+          body: JSON.stringify({ question: q, lang: langRef.current }),
           signal: AbortSignal.timeout(12000),
         });
         if (res.status === 429) {


### PR DESCRIPTION
## Summary

- **`components/chatbot/assistant.tsx`**: Add a `langRef` (`useRef` + `useEffect`) so the `/api/ask` fetch always sends the live locale (`langRef.current`), not the locale captured in a potentially stale `useCallback` render. The memoized `ask` callback can lag behind the current language if it hasn't been recreated yet (e.g. between `loading` state flips), causing subsequent requests to send `lang: "en"` instead of `"pt"`.
- **`app/api/ask/route.ts`**: Strengthen `buildSystemPrompt` for non-English locales. The previous `"Always reply in Portuguese"` instruction was routinely ignored by Groq/Grok models when the knowledge base is entirely in English. The new instruction is explicit and emphatic: `"MANDATORY LANGUAGE RULE: You MUST reply exclusively in Portuguese … never switch to English … if you reply in English you are violating this rule."` This forces the LLM to honour the locale on every turn, including follow-up chips.

## Test plan

- [ ] Open the portfolio in PT-BR (language toggle → PT)
- [ ] Open the chatbot widget
- [ ] Click the first FAQ prompt button → confirm response is in PT
- [ ] Click a follow-up chip that appears below the answer → confirm response is still in PT
- [ ] Click 3–4 more follow-ups or type new questions → all responses should remain in PT
- [ ] Repeat with ES, FR, ZH to confirm other non-EN locales also work

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multilingual responses by ensuring replies consistently use the selected language, including explanatory text and technical terms.
  * Updated chat requests to reflect the current language selection, including after locale settings finish loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->