### PR TITLE
Fix case-study pages leaking English text in non-EN languages

### DIFF
--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import { siteConfig, projects } from "@/lib/site-config";
 import { CaseStudyHeader } from "@/components/case-study-header";
@@ -96,11 +95,6 @@ export default async function CaseStudyPage({
       />
       <CaseStudyHeader />
       <main className="mx-auto max-w-3xl px-6 py-20 lg:py-28">
-        <nav aria-label="Breadcrumb" className="mb-8 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
-          <Link href="/" className="transition-colors hover:text-[var(--color-fg)]">Home</Link>
-          <span className="mx-2">/</span>
-          <Link href="/case-studies" className="transition-colors hover:text-[var(--color-fg)]">Case Studies</Link>
-        </nav>
         <CaseStudyBody project={project} />
       </main>
       <SiteFooter />

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -65,12 +65,6 @@ export default function CaseStudiesIndexPage() {
       />
       <CaseStudyHeader />
       <main className="mx-auto max-w-3xl px-6 py-20 lg:py-28">
-        <h1 className="font-display text-[clamp(2rem,4vw+0.5rem,3.25rem)] leading-[1.1] text-[var(--color-fg)] [text-wrap:balance]">
-          {title}
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-relaxed text-[var(--color-fg-muted)] sm:text-[17px]">
-          Real engagements, real numbers — the outcomes behind the résumé.
-        </p>
         <CaseStudiesIndexBody />
       </main>
       <SiteFooter />

--- a/components/case-studies-index-body.tsx
+++ b/components/case-studies-index-body.tsx
@@ -12,7 +12,14 @@ export function CaseStudiesIndexBody() {
   const reduce = useReducedMotion();
 
   return (
-    <div className="mt-12 space-y-6">
+    <div>
+      <h1 className="font-display text-[clamp(2rem,4vw+0.5rem,3.25rem)] leading-[1.1] text-[var(--color-fg)] [text-wrap:balance]">
+        {t.caseStudies.title}
+      </h1>
+      <p className="mt-4 max-w-2xl text-base leading-relaxed text-[var(--color-fg-muted)] sm:text-[17px]">
+        {t.caseStudies.subtitle}
+      </p>
+      <div className="mt-12 space-y-6">
       {projects.map((p, i) => {
         const tr = t.projects[p.id];
         const category = tr?.category ?? p.category;
@@ -42,7 +49,7 @@ export function CaseStudiesIndexBody() {
                   <p className="mt-1 font-mono text-xs text-[var(--color-fg-subtle)]">{client}</p>
                   <p className="mt-3 text-[15px] leading-relaxed text-[var(--color-fg-muted)]">{outcome}</p>
                   <span className="mt-3 inline-block text-sm font-medium text-[var(--color-blue)]">
-                    Read the full case study →
+                    {t.caseStudies.readFull}
                   </span>
                 </div>
               </m.article>
@@ -50,6 +57,7 @@ export function CaseStudiesIndexBody() {
           </Reveal>
         );
       })}
+      </div>
     </div>
   );
 }

--- a/components/case-study-body.tsx
+++ b/components/case-study-body.tsx
@@ -26,6 +26,11 @@ export function CaseStudyBody({ project: p }: { project: Project }) {
 
   return (
     <article>
+      <nav aria-label="Breadcrumb" className="mb-8 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+        <Link href="/" className="transition-colors hover:text-[var(--color-fg)]">{t.palette.home}</Link>
+        <span className="mx-2">/</span>
+        <Link href="/case-studies" className="transition-colors hover:text-[var(--color-fg)]">{t.caseStudies.title}</Link>
+      </nav>
       <Reveal>
         <span className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-blue)]">
           {category}
@@ -107,7 +112,7 @@ export function CaseStudyBody({ project: p }: { project: Project }) {
       <Reveal delay={0.3}>
         <div className="mt-16 flex flex-col items-start gap-4 border-t border-[var(--color-hairline)] pt-10 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-[15px] text-[var(--color-fg-muted)]">
-            Have a similar problem to solve?
+            {t.caseStudies.similarProblem}
           </p>
           <m.div whileTap={reduce ? undefined : { scale: 0.97 }}>
             <Link
@@ -115,7 +120,7 @@ export function CaseStudyBody({ project: p }: { project: Project }) {
               className="inline-flex items-center rounded-md px-6 py-3 text-sm font-medium text-white transition-all hover:opacity-90 hover:-translate-y-px active:translate-y-0"
               style={{ backgroundColor: "var(--color-button-primary)" }}
             >
-              Let&apos;s talk
+              {t.caseStudies.letsTalk}
             </Link>
           </m.div>
         </div>

--- a/components/case-study-header.tsx
+++ b/components/case-study-header.tsx
@@ -22,7 +22,7 @@ export function CaseStudyHeader() {
             href="/"
             className="font-ui text-[13px] text-[var(--color-fg-muted)] transition-colors hover:text-[var(--color-fg)]"
           >
-            ← Back to home
+            {t.caseStudies.backToHome}
           </Link>
           <LanguageSwitcher />
           <ThemeToggle />

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -235,6 +235,15 @@ type Dict = {
     tabAIChat: string;
     roleStrengths: Record<string, readonly string[]>;
   };
+  caseStudies: {
+    title: string;
+    subtitle: string;
+    breadcrumbHome: string;
+    backToHome: string;
+    readFull: string;
+    similarProblem: string;
+    letsTalk: string;
+  };
 };
 
 const en: Dict = {
@@ -676,6 +685,15 @@ const en: Dict = {
       "ai-infrastructure": ["Infrastructure foundation for AI: GPU scheduling, cost-aware inference platforms", "LLM integrations and RAG over private knowledge bases (production)", "Platform engineering directly applicable to MLOps infrastructure", "AI automation: cost anomaly detection, ops automation agents"],
       "consultant": ["Founder and principal of UP2CLOUD — B2B cloud consultancy (2022–present)", "International delivery: Portugal, Spain, Netherlands, UK, Brazil, US clients", "Enterprise track record: banking, aviation, media, staffing, automotive", "B2B model: fractional architecture, platform builds, FinOps engagements"],
     },
+  },
+  caseStudies: {
+    title: "Case Studies",
+    subtitle: "Real engagements, real numbers — the outcomes behind the résumé.",
+    breadcrumbHome: "Home",
+    backToHome: "← Back to home",
+    readFull: "Read the full case study →",
+    similarProblem: "Have a similar problem to solve?",
+    letsTalk: "Let's talk",
   },
 };
 
@@ -1119,6 +1137,15 @@ const pt: Dict = {
       "consultant": ["Fundador e principal da UP2CLOUD — consultoria cloud B2B (2022–presente)", "Entrega internacional: Portugal, Espanha, Holanda, UK, Brasil, clientes dos EUA", "Histórico enterprise: banca, aviação, media, staffing, automóvel", "Modelo B2B: arquitetura fracionada, construção de plataformas, projetos FinOps"],
     },
   },
+  caseStudies: {
+    title: "Estudos de Caso",
+    subtitle: "Projetos reais, números reais — os resultados por trás do currículo.",
+    breadcrumbHome: "Início",
+    backToHome: "← Voltar ao início",
+    readFull: "Ler o estudo de caso completo →",
+    similarProblem: "Tem um problema parecido para resolver?",
+    letsTalk: "Vamos conversar",
+  },
 };
 
 const es: Dict = {
@@ -1560,6 +1587,15 @@ const es: Dict = {
       "ai-infrastructure": ["Base de infraestructura para IA: programación de GPU, plataformas de inferencia conscientes del coste", "Integraciones LLM y RAG sobre bases de conocimiento privadas (producción)", "Ingeniería de plataforma directamente aplicable a infraestructura MLOps", "Automatización IA: detección de anomalías de coste, agentes de automatización de operaciones"],
       "consultant": ["Fundador y principal de UP2CLOUD — consultoría cloud B2B (2022–presente)", "Entrega internacional: Portugal, España, Países Bajos, UK, Brasil, clientes de EE.UU.", "Historial enterprise: banca, aviación, medios, staffing, automoción", "Modelo B2B: arquitectura fraccionada, construcción de plataformas, proyectos FinOps"],
     },
+  },
+  caseStudies: {
+    title: "Casos de Éxito",
+    subtitle: "Proyectos reales, números reales — los resultados detrás del currículum.",
+    breadcrumbHome: "Inicio",
+    backToHome: "← Volver al inicio",
+    readFull: "Leer el caso de éxito completo →",
+    similarProblem: "¿Tienes un problema similar que resolver?",
+    letsTalk: "Hablemos",
   },
 };
 
@@ -2003,6 +2039,15 @@ const fr: Dict = {
       "consultant": ["Fondateur et principal d'UP2CLOUD — conseil cloud B2B (2022–présent)", "Livraison internationale : Portugal, Espagne, Pays-Bas, Royaume-Uni, Brésil, clients US", "Références entreprise : banque, aviation, médias, staffing, automobile", "Modèle B2B : architecture fractionnée, construction de plateformes, missions FinOps"],
     },
   },
+  caseStudies: {
+    title: "Études de Cas",
+    subtitle: "Missions réelles, chiffres réels — les résultats derrière le CV.",
+    breadcrumbHome: "Accueil",
+    backToHome: "← Retour à l'accueil",
+    readFull: "Lire l'étude de cas complète →",
+    similarProblem: "Un problème similaire à résoudre ?",
+    letsTalk: "Discutons-en",
+  },
 };
 
 const zh: Dict = {
@@ -2444,6 +2489,15 @@ const zh: Dict = {
       "ai-infrastructure": ["AI 基础设施：GPU 调度、成本感知推理平台", "生产环境 LLM 集成与私有知识库 RAG", "平台工程直接适用于 MLOps 基础设施", "AI 自动化：成本异常检测、运维自动化代理"],
       "consultant": ["UP2CLOUD 创始人兼主理人——B2B 云咨询（2022–至今）", "国际交付：葡萄牙、西班牙、荷兰、英国、巴西、美国客户", "企业履历：银行、航空、媒体、人力资源、汽车", "B2B 模式：部分架构服务、平台构建、FinOps 项目"],
     },
+  },
+  caseStudies: {
+    title: "案例研究",
+    subtitle: "真实项目，真实数据 —— 简历背后的成果。",
+    breadcrumbHome: "首页",
+    backToHome: "← 返回首页",
+    readFull: "阅读完整案例研究 →",
+    similarProblem: "有类似的问题需要解决吗？",
+    letsTalk: "联系我",
   },
 };
 


### PR DESCRIPTION
## Summary

Continuation of the i18n-completeness sweep just done on up2cloud.tech, applied here. Audited `lib/i18n.tsx` for the same class of bug: strings that bypass the translation dictionary entirely.

Good news first: this repo's `Dict` type is fully structurally typed (`const en: Dict = {...}`, `const pt: Dict = {...}`, etc., `DICT: Record<Lang, Dict>`), so the "some languages missing a key" bug from up2cloud.tech literally can't happen here — `npm run type-check` already enforces it. A heuristic scan for identical-to-English values across pt/es/fr/zh turned up nothing but legitimate cognates and proper nouns (e.g. "Impact"/"Global"/"Contact" are spelled the same in French).

What I did find: the case-studies feature (`case-study-header.tsx`, `case-study-body.tsx`, `case-studies-index-body.tsx`) already calls `useI18n()` for most of its content, but a few strings were hardcoded and never wired through `t`:
- `case-study-header.tsx`: "← Back to home"
- `case-studies-index-body.tsx`: "Read the full case study →"
- `case-study-body.tsx`: "Have a similar problem to solve?", "Let's talk"
- `app/case-studies/page.tsx` and `app/case-studies/[slug]/page.tsx`: hardcoded H1/subtitle/breadcrumb ("Case Studies", "Home", the intro line) — these are Server Components, which can't call `useI18n()` (it's a React Context, client-only), so I moved that JSX into the already-client, already-`t`-aware body components instead of leaving it stuck in English.

Adds a `caseStudies` block to the `Dict` type (`title`, `subtitle`, `breadcrumbHome`, `backToHome`, `readFull`, `similarProblem`, `letsTalk`) with EN/PT/ES/FR/ZH translations. `breadcrumbHome` isn't actually a new string — the breadcrumb reuses the existing `t.palette.home` value instead.

## Test plan

- [x] `npm run type-check` passes (would fail immediately if any language were missing a `caseStudies` key)
- [x] `npm run lint` passes
- [x] `npm run build` succeeds, all 4 case-study routes (`/case-studies` + 3 slugs) generate
- [x] Inspected the generated static HTML for `/case-studies` and `/case-studies/finops-automation` — confirmed every previously-hardcoded string ("Case Studies", "Home", "Back to home", "Read the full case study", "Have a similar problem", "Let's talk") is still present in the default English SSR output, so nothing regressed for no-JS/SEO crawlers


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_