### PR TITLE
feat: mount FinOps+AiInfra sections, i18n form errors, API timeouts, dedupe KB

### DIFF
--- a/app/api/ask/route.ts
+++ b/app/api/ask/route.ts
@@ -1,32 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getIp, isRateLimited } from "@/lib/rate-limit";
-
-const KNOWLEDGE_BASE = `
-Cesar Augusto Nogueira — Principal Cloud Architect, Platform Engineer, DevOps Leader, FinOps Consultant and AI Infrastructure specialist. 10+ years in tech. Based in Vila Real, Portugal; works remotely with international clients via his consultancy UP2CLOUD. Available now for global remote consulting; usually replies within 24h.
-
-Business impact highlights:
-- Cut ~30% of cloud waste and automated chargeback for a global staffing leader (Randstad).
-- Built a real-time Big Data analytics platform on Google Cloud for a US mass-media corporation.
-- Delivered secure, observable multi-cloud at 99.9% availability for AndBank, Santander and LATAM Airlines.
-- Led a cloud-enablement team running GKE in production at Accenture.
-- ~30% cloud waste reduction documented; 40+ cloud projects; 6+ countries served.
-
-Certifications: 2x Google Cloud Professional Cloud Architect, Google Cloud Associate Cloud Engineer, AWS Cloud Practitioner, Microsoft Azure Fundamentals (AZ-900), applied FinOps.
-
-Experience:
-- UP2CLOUD (2022-now): Founder / Principal consultant — cloud architecture, automation, DevOps, FinOps, data engineering for global clients.
-- Randstad Digital Portugal (2022-2025): Cloud FinOps Automation Engineer — Python, multi-cloud billing APIs, CloudBees CI/CD, CloudHealth. Automated cost reporting, tagging, chargeback; ~30% waste removed.
-- ZeroLight (2021-2022): DevOps Engineer — automotive, AWS/GCP, Kubernetes.
-- Accenture Interactive Brazil (2020-2021): Technology Architecture Manager — GKE, Jenkins, Spinnaker, technical pre-sales, team leadership.
-- everis/NTT Data Brazil (2019-2020): Cloud Architect — GCP/AWS/Azure/OCI for AndBank, Santander, LATAM Airlines; PII security; observability.
-- CI&T (2017-2019): Software Engineer — Big Data on GCP (Apache Beam, DataFlow, BigQuery, App Engine), Java/Node/React.
-
-Industries: Banking, Aviation, Media, Staffing, Automotive, Consulting. Countries: Portugal, Spain, Netherlands, UK, Brazil, US clients.
-
-Skills: GCP, AWS, Azure, OCI, Kubernetes, Terraform, Docker, Argo, GitHub Actions, GitLab CI, Jenkins/CloudBees, BigQuery, Dataform, dbt, Apache Beam, Python, Java, FinOps, Observability, AI infrastructure (LLMs, OpenAI integrations, RAG).
-
-Contact: cesarnogueira1210@gmail.com, LinkedIn linkedin.com/in/cesarnog, GitHub github.com/cesarnog.
-`.trim();
+import { knowledgeBase } from "@/lib/site-config";
 
 const LANG_NAMES: Record<string, string> = { en: "English", pt: "Brazilian Portuguese", es: "Spanish", fr: "French", zh: "Chinese" };
 
@@ -35,7 +9,7 @@ function buildSystemPrompt(lang: string): string {
   const langRule = lang === "en"
     ? "Always reply in English."
     : `MANDATORY LANGUAGE RULE: You MUST reply exclusively in ${langName}. Never switch to English, even for technical terms — keep all explanatory prose in ${langName}. If you reply in English you are violating this rule.`;
-  return `You are the AI Career Assistant for Principal Cloud Architect Cesar Augusto Nogueira. Your audience is recruiters, CTOs, VPs of Engineering, Platform Directors, Heads of Cloud and Founders evaluating Cesar for a role or consulting engagement. Act as an expert representative of the candidate: answer concisely (2-4 sentences), professionally and in the third person, and always lead with seniority, scale, business impact, leadership or availability where relevant. Use ONLY the facts below. If asked something unrelated or unknown, briefly steer back to Cesar's professional fit and suggest emailing him. Never invent employers, certifications or numbers. ${langRule}\n\nFACTS:\n${KNOWLEDGE_BASE}`;
+  return `You are the AI Career Assistant for Principal Cloud Architect Cesar Augusto Nogueira. Your audience is recruiters, CTOs, VPs of Engineering, Platform Directors, Heads of Cloud and Founders evaluating Cesar for a role or consulting engagement. Act as an expert representative of the candidate: answer concisely (2-4 sentences), professionally and in the third person, and always lead with seniority, scale, business impact, leadership or availability where relevant. Use ONLY the facts below. If asked something unrelated or unknown, briefly steer back to Cesar's professional fit and suggest emailing him. Never invent employers, certifications or numbers. ${langRule}\n\nFACTS:\n${knowledgeBase}`;
 }
 
 export async function POST(req: NextRequest) {
@@ -76,6 +50,7 @@ export async function POST(req: NextRequest) {
   try {
     const r = await fetch(endpoint, {
       method: "POST",
+      signal: AbortSignal.timeout(9000),
       headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
       body: JSON.stringify({
         model,

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -119,18 +119,24 @@ export async function POST(req: NextRequest) {
 </body>
 </html>`;
 
-  const r = await fetch("https://api.resend.com/emails", {
-    method: "POST",
-    signal: AbortSignal.timeout(9000),
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
-    body: JSON.stringify({
-      from: FROM,
-      to: TO,
-      reply_to: email,
-      subject: subject ? `✉ ${subject} — from ${name}` : `✉ New message from ${name}`,
-      html,
-    }),
-  });
+  let r: Response;
+  try {
+    r = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      signal: AbortSignal.timeout(9000),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        from: FROM,
+        to: TO,
+        reply_to: email,
+        subject: subject ? `✉ ${subject} — from ${name}` : `✉ New message from ${name}`,
+        html,
+      }),
+    });
+  } catch (err) {
+    const isTimeout = err instanceof DOMException && err.name === "TimeoutError";
+    return NextResponse.json({ error: "Send failed" }, { status: isTimeout ? 504 : 502 });
+  }
 
   if (!r.ok) {
     return NextResponse.json({ error: "Send failed" }, { status: 500 });

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -121,6 +121,7 @@ export async function POST(req: NextRequest) {
 
   const r = await fetch("https://api.resend.com/emails", {
     method: "POST",
+    signal: AbortSignal.timeout(9000),
     headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
     body: JSON.stringify({
       from: FROM,

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -5,8 +5,7 @@ import { SiteFooter } from "@/components/site-footer";
 import { CaseStudiesIndexBody } from "@/components/case-studies-index-body";
 
 const title = "Case Studies";
-const description =
-  "Real cloud, FinOps, and platform engineering engagements — FinOps automation, big data platforms, and regulated banking infrastructure.";
+const description = siteConfig.caseStudiesDescription;
 
 export const metadata: Metadata = {
   title,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,12 @@ const InfraCanvas = dynamic(
 );
 
 // Below-fold sections — split into separate JS chunks, load after first paint
+const FinOps = dynamic(
+  () => import("@/components/sections/finops").then(m => m.FinOps)
+);
+const AiInfra = dynamic(
+  () => import("@/components/sections/ai-infra").then(m => m.AiInfra)
+);
 const GlobalMap = dynamic(
   () => import("@/components/sections/global-map").then(m => m.GlobalMap)
 );
@@ -51,9 +57,11 @@ export default function Home() {
         <Story />
         <ExperienceTimeline />
         <Projects />
+        <FinOps />
         <Trust />
         <GlobalMap />
         <CapabilityMatrix />
+        <AiInfra />
         <Certifications />
         <CloudGalaxy />
         <Testimonials />

--- a/components/sections/finops.tsx
+++ b/components/sections/finops.tsx
@@ -62,6 +62,9 @@ export function FinOps() {
               />
             </svg>
           </div>
+          <p className="mt-2 font-mono text-[10px] text-[var(--color-fg-subtle)] opacity-70">
+            Illustrative trend · based on a real ~30% reduction at Randstad Digital (11-month window)
+          </p>
           <div className="mt-4 grid grid-cols-3 gap-3">
             {finops.metrics.slice(0, 3).map((metric) => (
               <div key={metric.label} className="panel-2 rounded-md p-3">

--- a/components/sections/finops.tsx
+++ b/components/sections/finops.tsx
@@ -63,7 +63,7 @@ export function FinOps() {
             </svg>
           </div>
           <p className="mt-2 font-mono text-[10px] text-[var(--color-fg-subtle)] opacity-70">
-            Illustrative trend · based on a real ~30% reduction at Randstad Digital (11-month window)
+            {t.labels.finopsTrendDisclosure}
           </p>
           <div className="mt-4 grid grid-cols-3 gap-3">
             {finops.metrics.slice(0, 3).map((metric) => (

--- a/components/ui/contact-form-modal.tsx
+++ b/components/ui/contact-form-modal.tsx
@@ -50,10 +50,10 @@ export function ContactFormModal({ open, onClose }: Props) {
 
   function validate() {
     const errors = { name: "", email: "", message: "" };
-    if (!form.name.trim()) errors.name = "Name is required.";
-    if (!form.email.trim()) errors.email = "Email is required.";
-    else if (!validateEmail(form.email)) errors.email = "Enter a valid email address.";
-    if (!form.message.trim()) errors.message = "Message is required.";
+    if (!form.name.trim()) errors.name = c.formNameRequired;
+    if (!form.email.trim()) errors.email = c.formEmailRequired;
+    else if (!validateEmail(form.email)) errors.email = c.formEmailInvalid;
+    if (!form.message.trim()) errors.message = c.formMessageRequired;
     setFieldErrors(errors);
     return !errors.name && !errors.email && !errors.message;
   }

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -6,17 +6,16 @@ async function openHiringAssistant(page: Page) {
   // EN: "Ask about César" / PT-BR|ES: "FAQ Inteligente" / FR: "FAQ IA"
   const launcher = page.getByRole("button", { name: /ask about|FAQ/i }).first();
   await launcher.waitFor({ state: "visible", timeout: 10000 });
-  // Click and retry until the dialog appears — handles React hydration delay
+  // Retry clicking until the dialog appears — handles React hydration delay.
   // (aria-expanded="false" is in SSR HTML so it's not a reliable hydration signal)
-  const dialog = page.getByRole("dialog", { name: /career assistant|assistente|asistente|assistant carrière|AI职业/i });
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const alreadyOpen = await dialog.isVisible().catch(() => false);
-    if (alreadyOpen) break;
-    await launcher.click();
-    await page.waitForTimeout(300);
-  }
   // EN: "AI Career Assistant" / PT-BR: "Assistente de Carreira IA" / ES: "Asistente de Carrera IA"
-  await expect(dialog).toBeVisible({ timeout: 3000 });
+  const dialog = page.getByRole("dialog", { name: /career assistant|assistente|asistente|assistant carrière|AI职业/i });
+  await expect.poll(async () => {
+    if (await dialog.isVisible().catch(() => false)) return true;
+    await launcher.click().catch(() => {});
+    return false;
+  }, { timeout: 8000, intervals: [300] }).toBe(true);
+  await expect(dialog).toBeVisible({ timeout: 2000 });
 }
 
 async function expectAssistantToBeClosed(page: Page) {
@@ -52,8 +51,7 @@ async function expectBodyScrollable(page: Page) {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/");
-  await page.waitForLoadState("domcontentloaded");
+  await page.goto("/", { waitUntil: "domcontentloaded" });
 });
 
 test.describe("Navigation while Hiring Assistant is open", () => {
@@ -190,8 +188,7 @@ test.describe("Direct hash and browser navigation", () => {
   });
 
   test("browser back and forward remain functional", async ({ page }) => {
-    await page.goto("/");
-    await page.waitForLoadState("domcontentloaded");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
 
     // Scroll to a section
     const navLinks = page.getByRole("navigation", { name: "Main navigation" }).getByRole("link");
@@ -210,8 +207,7 @@ test.describe("Direct hash and browser navigation", () => {
 test.describe("Reduced-motion mode", () => {
   test("navigation works under prefers-reduced-motion", async ({ page }) => {
     await page.emulateMedia({ reducedMotion: "reduce" });
-    await page.goto("/");
-    await page.waitForLoadState("domcontentloaded");
+    await page.goto("/", { waitUntil: "domcontentloaded" });
 
     await openHiringAssistant(page);
 

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -109,6 +109,7 @@ type Dict = {
     verified: string;
     loadingGalaxy: string;
     operatingModel: string;
+    finopsTrendDisclosure: string;
     monthlyCostLabel: string;
     filterAll: string;
     filterEurope: string;
@@ -450,6 +451,7 @@ const en: Dict = {
     verified: "verified",
     loadingGalaxy: "loading galaxy…",
     operatingModel: "Operating model",
+    finopsTrendDisclosure: "Illustrative trend · based on a real ~30% reduction at Randstad Digital (11-month window)",
     monthlyCostLabel: "Monthly cloud spend · optimized",
     filterAll: "All",
     filterEurope: "Europe",
@@ -905,6 +907,7 @@ const pt: Dict = {
     verified: "verificadas",
     loadingGalaxy: "carregando galáxia…",
     operatingModel: "Modelo operacional",
+    finopsTrendDisclosure: "Tendência ilustrativa · baseada em redução real de ~30% na Randstad Digital (janela de 11 meses)",
     monthlyCostLabel: "Custo mensal cloud · otimizado",
     filterAll: "Todos",
     filterEurope: "Europa",
@@ -1360,6 +1363,7 @@ const es: Dict = {
     verified: "verificadas",
     loadingGalaxy: "cargando galaxia…",
     operatingModel: "Modelo operativo",
+    finopsTrendDisclosure: "Tendencia ilustrativa · basada en una reducción real de ~30% en Randstad Digital (ventana de 11 meses)",
     monthlyCostLabel: "Gasto mensual cloud · optimizado",
     filterAll: "Todos",
     filterEurope: "Europa",
@@ -1815,6 +1819,7 @@ const fr: Dict = {
     verified: "vérifiées",
     loadingGalaxy: "chargement de la galaxie…",
     operatingModel: "Modèle opérationnel",
+    finopsTrendDisclosure: "Tendance illustrative · basée sur une réduction réelle de ~30% chez Randstad Digital (fenêtre de 11 mois)",
     monthlyCostLabel: "Dépenses cloud mensuelles · optimisées",
     filterAll: "Tous",
     filterEurope: "Europe",
@@ -2270,6 +2275,7 @@ const zh: Dict = {
     verified: "已验证",
     loadingGalaxy: "加载星系中…",
     operatingModel: "运营模型",
+    finopsTrendDisclosure: "示意性趋势 · 基于Randstad Digital实际降低约30%的成本（11个月窗口期）",
     monthlyCostLabel: "每月云支出 · 已优化",
     filterAll: "全部",
     filterEurope: "欧洲",

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -79,6 +79,10 @@ type Dict = {
     formSuccess: string;
     formSuccessDesc: string;
     formError: string;
+    formNameRequired: string;
+    formEmailRequired: string;
+    formEmailInvalid: string;
+    formMessageRequired: string;
     rowLabels: {
       email: string;
       linkedin: string;
@@ -416,6 +420,10 @@ const en: Dict = {
     formSuccess: "Message sent",
     formSuccessDesc: "Cesar will be in touch within 24 hours.",
     formError: "Something went wrong. Email directly:",
+    formNameRequired: "Name is required.",
+    formEmailRequired: "Email is required.",
+    formEmailInvalid: "Enter a valid email address.",
+    formMessageRequired: "Message is required.",
     rowLabels: {
       email: "Email",
       linkedin: "LinkedIn",
@@ -867,6 +875,10 @@ const pt: Dict = {
     formSuccess: "Mensagem enviada",
     formSuccessDesc: "O Cesar responderá em 24 horas.",
     formError: "Algo correu mal. Envie diretamente para:",
+    formNameRequired: "O nome é obrigatório.",
+    formEmailRequired: "O email é obrigatório.",
+    formEmailInvalid: "Insira um endereço de email válido.",
+    formMessageRequired: "A mensagem é obrigatória.",
     rowLabels: {
       email: "Email",
       linkedin: "LinkedIn",
@@ -1318,6 +1330,10 @@ const es: Dict = {
     formSuccess: "Mensaje enviado",
     formSuccessDesc: "Cesar te responderá en 24 horas.",
     formError: "Algo salió mal. Escribe directamente a:",
+    formNameRequired: "El nombre es obligatorio.",
+    formEmailRequired: "El email es obligatorio.",
+    formEmailInvalid: "Introduce una dirección de email válida.",
+    formMessageRequired: "El mensaje es obligatorio.",
     rowLabels: {
       email: "Email",
       linkedin: "LinkedIn",
@@ -1769,6 +1785,10 @@ const fr: Dict = {
     formSuccess: "Message envoyé",
     formSuccessDesc: "Cesar vous répondra dans les 24 heures.",
     formError: "Une erreur s'est produite. Écrivez directement à :",
+    formNameRequired: "Le nom est requis.",
+    formEmailRequired: "L'email est requis.",
+    formEmailInvalid: "Saisissez une adresse email valide.",
+    formMessageRequired: "Le message est requis.",
     rowLabels: {
       email: "Email",
       linkedin: "LinkedIn",
@@ -2220,6 +2240,10 @@ const zh: Dict = {
     formSuccess: "消息已发送",
     formSuccessDesc: "Cesar将在24小时内与您联系。",
     formError: "出现错误。请直接发邮件至：",
+    formNameRequired: "姓名为必填项。",
+    formEmailRequired: "邮箱为必填项。",
+    formEmailInvalid: "请输入有效的邮箱地址。",
+    formMessageRequired: "消息为必填项。",
     rowLabels: {
       email: "邮箱",
       linkedin: "LinkedIn",

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -38,6 +38,8 @@ export const siteConfig = {
     "Observability",
     "AI Infrastructure",
   ],
+  caseStudiesDescription:
+    "Real cloud, FinOps, and platform engineering engagements — FinOps automation, big data platforms, and regulated banking infrastructure.",
   links: {
     linkedin: "https://www.linkedin.com/in/cesarnog/",
     github: "https://github.com/cesarnog",


### PR DESCRIPTION
## Summary

- **Mount FinOps + AiInfra sections** — both components were fully implemented and wired to real data in `lib/site-config.ts` but never imported or rendered in `app/page.tsx`. Visitors to the live site couldn't see the FinOps dashboard or AI Infrastructure panel, which are core differentiators. FinOps now appears after Projects; AiInfra appears before Certifications.

- **Contact form validation i18n** — validation error strings (`"Name is required."`, etc.) were hardcoded English in `contact-form-modal.tsx`. Added 4 new keys (`formNameRequired`, `formEmailRequired`, `formEmailInvalid`, `formMessageRequired`) to the TypeScript type and all 5 language dictionaries (EN/PT-BR/ES/FR/ZH). Non-English visitors now see errors in their selected language.

- **Server-side fetch timeouts** — added `AbortSignal.timeout(9000)` to the upstream LLM call in `/api/ask` and the Resend call in `/api/contact`. Without this, a hanging provider keeps a Vercel function running until the 30s hard ceiling, wasting billing time.

- **Deduplicate knowledge base** — removed the hand-maintained `KNOWLEDGE_BASE` constant from `/api/ask/route.ts` and replaced it with `import { knowledgeBase } from "@/lib/site-config"` (the declared single source of truth). Previously the two could drift silently on any career update.

- **Sparkline disclosure** — added a visible footnote beneath the FinOps cost-trend chart: *"Illustrative trend · based on a real ~30% reduction at Randstad Digital (11-month window)"* so the chart is clearly attributed rather than appearing as live telemetry.

## Test plan

- [ ] Live site renders FinOps section after Projects (sparkline, metrics row, pillars)
- [ ] Live site renders AI Infrastructure section before Certifications (capability cards)
- [ ] Submit contact form in PT-BR/ES/FR/ZH with empty fields — validation errors appear in the correct language
- [ ] Type check passes: `npm run type-check`

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FinOps and AI infrastructure sections to the homepage.
  * Added localized contact-form validation messages in five languages.
  * Improved case study page titles and descriptions for search and social sharing.
  * Added explanatory context to the FinOps cost-trend chart.

* **Bug Fixes**
  * Added timeout handling for assistant and contact requests.

* **Tests**
  * Improved navigation tests for localization, hydration delays, and hash scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->