### PR TITLE
fix(a11y): correct ARIA roles in LanguageSwitcher and add mobile nav focus trap

### DIFF
--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -32,7 +32,7 @@ export function LanguageSwitcher({ className = "" }: { className?: string }) {
         type="button"
         aria-label={`${current.label}, Language: ${current.name}. Click to change.`}
         aria-expanded={open}
-        aria-haspopup="listbox"
+        aria-haspopup="menu"
         onClick={() => setOpen((o) => !o)}
         className="flex items-center gap-1.5 rounded-md border border-[var(--color-hairline)] px-2 py-1.5 font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)] transition-colors hover:border-[var(--color-hairline-strong)] hover:text-[var(--color-fg)]"
       >
@@ -55,7 +55,7 @@ export function LanguageSwitcher({ className = "" }: { className?: string }) {
 
       {open && (
         <div
-          role="listbox"
+          role="menu"
           aria-label="Select language"
           className="absolute right-0 top-full mt-1.5 min-w-[148px] overflow-hidden rounded-lg border border-[var(--color-hairline-strong)] bg-[var(--color-surface-1)] py-1 shadow-xl"
           style={{ zIndex: 200 }}
@@ -66,8 +66,8 @@ export function LanguageSwitcher({ className = "" }: { className?: string }) {
               <button
                 key={l.code}
                 type="button"
-                role="option"
-                aria-selected={active}
+                role="menuitemradio"
+                aria-checked={active}
                 onClick={() => { setLang(l.code); setOpen(false); }}
                 className={`flex w-full items-center gap-2.5 px-3 py-2 text-left font-mono text-[11px] transition-colors ${
                   active

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -60,6 +60,31 @@ export function SiteHeader() {
     return () => { document.body.style.overflow = ""; };
   }, [mobileOpen]);
 
+  // Tab focus trap for mobile nav dialog.
+  useEffect(() => {
+    if (!mobileOpen || !menuRef.current) return;
+    const dialog = menuRef.current;
+    const focusable = () => dialog.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), a[href], input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    );
+    // Move focus into the dialog on open.
+    (focusable()[0] as HTMLElement | undefined)?.focus();
+    const trap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const els = focusable();
+      if (!els.length) return;
+      const first = els[0];
+      const last = els[els.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    document.addEventListener("keydown", trap);
+    return () => document.removeEventListener("keydown", trap);
+  }, [mobileOpen]);
+
   const openPalette = () => {
     document.dispatchEvent(
       new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }),
@@ -177,6 +202,7 @@ export function SiteHeader() {
               ref={menuRef}
               id="mobile-nav"
               role="dialog"
+              aria-modal="true"
               aria-label="Navigation menu"
               initial={reduce ? { opacity: 0 } : { opacity: 0, x: "100%" }}
               animate={{ opacity: 1, x: 0 }}


### PR DESCRIPTION
## Summary

Two ARIA/accessibility fixes identified by the audit fleet.

- **LanguageSwitcher invalid `role="option"` on `<button>`** — the `role="option"` attribute is only valid on elements inside a `role="listbox"`, and `<button>` elements are prohibited from having that role. Screen readers (NVDA, VoiceOver, JAWS) will either ignore the role or raise a validation error. Fixed by switching to the `role="menu"` / `role="menuitemradio"` pattern, which is fully valid for `<button>` elements and correctly communicates single-select menu semantics. Also updated the trigger's `aria-haspopup` from `"listbox"` to `"menu"` to match.

- **Mobile nav drawer missing `aria-modal` and Tab focus trap** — the drawer already had `role="dialog"`, Escape handling, and body scroll lock. Missing `aria-modal="true"` meant screen readers would not constrain virtual cursor to the dialog. Missing Tab focus trap meant keyboard users could Tab out of the open drawer. Added both: `aria-modal="true"` on the dialog element, and a `useEffect` that moves focus to the first focusable element on open and wraps Tab/Shift+Tab within the dialog's focusable elements.

## Test plan

- [ ] Open language switcher → inspect with browser a11y tools — no ARIA role errors
- [ ] Open mobile nav → Tab through items → focus stays inside the drawer
- [ ] Open mobile nav → Shift+Tab from first item → wraps to last item
- [ ] Screen reader (VoiceOver/NVDA) announces the language menu correctly as a radio group


---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_