### PR TITLE
fix(seo): expand the thin case-studies index title (weekly check 2026-08-11)

### DIFF
--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -4,7 +4,7 @@ import { CaseStudyHeader } from "@/components/case-study-header";
 import { SiteFooter } from "@/components/site-footer";
 import { CaseStudiesIndexBody } from "@/components/case-studies-index-body";
 
-const title = "Case Studies";
+const title = "Cloud, FinOps & Data Case Studies";
 const description = siteConfig.caseStudiesDescription;
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary

Weekly SEO health check for cesarnogueira.tech. The site is in good shape — one genuine finding, fixed here.

**The case-studies index title was 37 characters** (`Case Studies · César Augusto Nogueira`), well under the 50–60 target, leaving most of the SERP snippet width unused and saying nothing about what the studies actually cover.

Now `Cloud, FinOps & Data Case Studies · César Augusto Nogueira` (58) — matching the three published studies: `banking-cloud`, `finops-automation`, `bigdata-platform`. The shared `title` const feeds `og:title`, `twitter:title` and the `CollectionPage` JSON-LD name, so all four stay consistent automatically.

### Everything else checked out clean

- `npm run lint` and `npm run type-check` — both pass
- `npm run build` — succeeds, all 3 case studies prerendered via `generateStaticParams`
- All production URLs 200: `/`, `/case-studies`, `/robots.txt`, `/sitemap.xml`, and all 3 case-study slugs
- `sitemap.xml` well-formed, all 5 `<loc>` URLs 200
- **hreflang self-reference has NOT regressed** — every entry's `en` and `x-default` alternates point at that entry's own URL, not the homepage. `selfLanguages(url)` in `app/sitemap.ts` receives each page's own URL, and the guarding comment is still in place
- JSON-LD `@graph` in `app/layout.tsx` parses clean — `Person`, `WebSite`, `ProfessionalService`
- **up2cloud.tech cross-links intact**: `Person.sameAs` → `https://up2cloud.tech/about/` (200), `ProfessionalService.sameAs` → `https://up2cloud.tech` (200). GitHub returns 403 and LinkedIn 999 to curl — anti-bot responses, not broken links; x.com is 200
- Canonicals correct on every page, exactly one `<h1>` each
- Every `next/image` has `alt` (both `<Image>` hits from a line-based grep are multi-line JSX with `alt={siteConfig.name}` on the following line)

### Left as a suggestion, not changed

The homepage title is **62 chars** (`César Nogueira · Principal Cloud Architect & FinOps Consultant`) — 2 over the 60 guideline. Google truncates on pixel width rather than a hard character count, and the homepage title is the site's primary brand signal, so trimming it for 2 characters is a judgment call rather than a mechanical fix.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run build` — succeeds
- [x] Verified against the prerendered build output (`.next/server/app/case-studies.html`): title / `og:title` / `twitter:title` all 58 chars, description 135, canonical `https://cesarnogueira.tech/case-studies`, 2 JSON-LD blocks parsing clean, exactly one `<h1>`
- [x] Diff is one line in one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_