### PR TITLE
fix(a11y): Tab focus traps for scanner/recruiter dialogs + send button contrast

### DIFF
--- a/components/chatbot/assistant.tsx
+++ b/components/chatbot/assistant.tsx
@@ -431,7 +431,7 @@ export function Assistant() {
                 disabled={loading || !input.trim()}
                 aria-label="Send message"
                 whileTap={reduce ? undefined : { scale: 0.87, transition: { duration: DUR.micro, ease: EASE.in } }}
-                className="bg-accent accent-blue flex h-9 w-9 items-center justify-center rounded-md text-sm font-medium text-white disabled:opacity-40"
+                className="flex h-9 w-9 items-center justify-center rounded-md text-sm font-medium text-white disabled:opacity-40 bg-[var(--accent-blue-light)]"
               >
                 ↑
               </m.button>

--- a/components/recruiter-mode.tsx
+++ b/components/recruiter-mode.tsx
@@ -266,6 +266,7 @@ export function RecruiterMode() {
   const reduce = useReducedMotion();
   const { t, lang } = useI18n();
 
+  const panelRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const chatListRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<HTMLInputElement>(null);
@@ -331,6 +332,28 @@ export function RecruiterMode() {
     const h = (e: KeyboardEvent) => { if (e.key === "Escape") setPanelOpen(false); };
     document.addEventListener("keydown", h);
     return () => document.removeEventListener("keydown", h);
+  }, [panelOpen]);
+
+  // Tab focus trap — WCAG 2.1 SC 2.1.1
+  useEffect(() => {
+    if (!panelOpen || !panelRef.current) return;
+    const dialog = panelRef.current;
+    const trap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    document.addEventListener("keydown", trap);
+    return () => document.removeEventListener("keydown", trap);
   }, [panelOpen]);
 
   const enableRecruiter = () => {
@@ -446,6 +469,7 @@ export function RecruiterMode() {
             />
 
             <m.div
+              ref={panelRef}
               id={PANEL_ID}
               role="dialog"
               aria-label="AI Hiring Assistant — César A. Nogueira"

--- a/components/recruiter-scanner.tsx
+++ b/components/recruiter-scanner.tsx
@@ -226,6 +226,7 @@ export function RecruiterScanner() {
   const [activeScoringIdx, setActiveScoringIdx] = useState(-1);
   const [mounted, setMounted] = useState(false);
   const reduce = useReducedMotion();
+  const dialogRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const verdictRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
@@ -296,6 +297,28 @@ export function RecruiterScanner() {
     return () => document.removeEventListener("keydown", h);
   }, [phase]);
 
+  // Tab focus trap — WCAG 2.1 SC 2.1.1
+  useEffect(() => {
+    if (phase === "idle" || !dialogRef.current) return;
+    const dialog = dialogRef.current;
+    const trap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), a[href], input:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) { e.preventDefault(); last.focus(); }
+      } else {
+        if (document.activeElement === last) { e.preventDefault(); first.focus(); }
+      }
+    };
+    document.addEventListener("keydown", trap);
+    return () => document.removeEventListener("keydown", trap);
+  }, [phase]);
+
   // ⌘⇧E (Mac) / Ctrl⇧E (Win/Linux) — keyboard shortcut to open scanner
   useEffect(() => {
     const h = (e: KeyboardEvent) => {
@@ -341,6 +364,7 @@ export function RecruiterScanner() {
   return createPortal(
     <>
     <div
+      ref={dialogRef}
       role="dialog"
       aria-label="Candidate Evaluation — César A. Nogueira"
       aria-modal="true"


### PR DESCRIPTION
## Summary

Fixes remaining a11y findings from the fleet audit (the ones rate limits prevented from shipping in the previous round):

- **RecruiterScanner** (`components/recruiter-scanner.tsx`): Added `dialogRef` + Tab focus trap `useEffect` — Tab/Shift+Tab now cycles within the full-screen evaluation overlay. WCAG 2.1 SC 2.1.1.
- **RecruiterMode panel** (`components/recruiter-mode.tsx`): Added `panelRef` + Tab focus trap `useEffect` — Tab/Shift+Tab now cycles within the hiring assistant side panel. WCAG 2.1 SC 2.1.1.
- **Chat send button** (`components/chatbot/assistant.tsx`): Switched from `bg-accent accent-blue` (resolves to `#3b82f6` in dark mode, 3.95:1 against white — fails WCAG AA) to `bg-[var(--accent-blue-light)]` (`#1f6fe0`, 4.7:1 in both modes — passes WCAG AA).

## What wasn't changed

Both dialogs already had `role="dialog"`, `aria-modal="true"`, Escape-key close handlers, and initial focus moved to the close/back button on open. This PR adds only the missing Tab trap on top of that solid foundation.

## Test plan

- [ ] Open RecruiterScanner (⌘⇧E or "Evaluate César" button) → Tab through all controls → confirm focus wraps from last to first and Shift+Tab wraps from first to last
- [ ] Open Recruiter Mode panel (bottom-left button) → Tab through → confirm same wrap behaviour across both Roles and Chat tabs
- [ ] Open chat assistant → check send button background in both light and dark themes — should be a clearly accessible solid blue

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_