### PR TITLE
feat(design): 2026 animation upgrades — gradient headings, card shine, hover glow, hero levitation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -506,6 +506,125 @@ body.tab-hidden .aurora-blob {
   background: color-mix(in oklab, var(--color-blue) 3%, var(--color-surface-1));
 }
 
+/* ════════════════════════════════════════════════════════════════════════════
+   2026 ANIMATION SYSTEM — gradient headings, card shine, hover glow, levitation
+   ════════════════════════════════════════════════════════════════════════════ */
+
+/* ── Animated gradient text ───────────────────────────────────────────────── */
+/* Slow color sweep: near-white → brand blue → cloud cyan → near-white.
+   -webkit-text-fill-color wins over `color` in Chrome/Safari; `color:
+   transparent` + background-clip covers Firefox. The reduced-motion branch
+   resets every property so the text stays legible without animation. */
+@keyframes gradient-pan {
+  0%   { background-position: 0%   50%; }
+  50%  { background-position: 100% 50%; }
+  100% { background-position: 0%   50%; }
+}
+.gradient-heading {
+  background: linear-gradient(
+    90deg,
+    var(--color-fg)   0%,
+    var(--color-blue) 28%,
+    var(--color-cyan) 55%,
+    var(--color-fg)   100%
+  );
+  background-size: 250% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  animation: gradient-pan 8s ease infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .gradient-heading {
+    animation: none;
+    -webkit-text-fill-color: var(--color-fg);
+    -webkit-background-clip: unset;
+    background-clip: unset;
+    background: none;
+    color: var(--color-fg);
+  }
+}
+[data-reduce-motion="1"] .gradient-heading {
+  animation: none;
+  -webkit-text-fill-color: var(--color-fg);
+  -webkit-background-clip: unset;
+  background-clip: unset;
+  background: none;
+  color: var(--color-fg);
+}
+
+/* ── Levitation float ─────────────────────────────────────────────────────── */
+/* Sinusoidal hover for hero portrait and selected featured elements. */
+@keyframes levitate {
+  0%, 100% { transform: translateY(0);    }
+  50%       { transform: translateY(-8px); }
+}
+.animate-levitate {
+  animation: levitate 5s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .animate-levitate { animation: none; }
+}
+[data-reduce-motion="1"] .animate-levitate { animation: none; }
+
+/* ── Card shine — diagonal light sweep on hover ───────────────────────────── */
+/* A single-pass shimmer that fires once on hover / focus-within, then resets.
+   Uses ::after so the host element keeps its own border-radius clip. */
+@keyframes card-shine {
+  from { transform: translateX(-200%) skewX(-20deg); opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  to   { transform: translateX(350%) skewX(-20deg); opacity: 0; }
+}
+.card-shine {
+  position: relative;
+  overflow: hidden;
+}
+.card-shine::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 35%,
+    color-mix(in oklab, white 7%, transparent) 50%,
+    transparent 65%
+  );
+  transform: translateX(-200%) skewX(-20deg);
+  pointer-events: none;
+  z-index: 1;
+}
+.card-shine:hover::after,
+.card-shine:focus-within::after {
+  animation: card-shine 0.65s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .card-shine::after { display: none; }
+}
+[data-reduce-motion="1"] .card-shine::after { display: none; }
+
+/* ── Card hover glow ─────────────────────────────────────────────────────── */
+/* Adds a blue edge glow + box-shadow lift on hover to interactive cards.
+   Intended to pair with .card-shine on the same element. */
+.card-glow {
+  transition:
+    border-color 0.3s cubic-bezier(0.16, 1, 0.3, 1),
+    box-shadow   0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.card-glow:hover {
+  border-color: color-mix(in oklab, var(--color-blue) 35%, var(--color-hairline));
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--color-blue) 10%, transparent),
+    0 12px 40px -16px color-mix(in oklab, var(--color-blue) 28%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .card-glow { transition: none; }
+  .card-glow:hover { box-shadow: none; border-color: var(--color-hairline-strong); }
+}
+[data-reduce-motion="1"] .card-glow { transition: none; }
+[data-reduce-motion="1"] .card-glow:hover { box-shadow: none; border-color: var(--color-hairline-strong); }
+
 /* ─── Print stylesheet — clean CV output ─────────────────────────────────── */
 @media print {
   /* Force light mode colors */

--- a/components/case-studies-index-body.tsx
+++ b/components/case-studies-index-body.tsx
@@ -33,7 +33,7 @@ export function CaseStudiesIndexBody() {
             <Link href={`/case-studies/${p.id}`} className="block">
               <m.article
                 whileHover={reduce ? undefined : cardHover}
-                className="panel grid gap-6 rounded-xl p-6 transition-colors hover:border-[var(--color-hairline-strong)] sm:grid-cols-[auto_1fr] sm:items-center sm:p-8"
+                className="panel card-shine card-glow grid gap-6 rounded-xl p-6 sm:grid-cols-[auto_1fr] sm:items-center sm:p-8"
               >
                 <div className="text-left sm:text-center">
                   <p className="font-display text-4xl text-[var(--color-fg)]">{p.metric}</p>

--- a/components/hero/identity-console.tsx
+++ b/components/hero/identity-console.tsx
@@ -272,7 +272,16 @@ export function IdentityConsole() {
             transition: { duration: 1.1, delay: DELAYS.photo, ease: EASE.out },
           })}
         >
-          <Image src="/portrait.webp" alt={siteConfig.name} fill sizes="52vw" className="object-cover object-top" priority loading="eager" />
+          {/* Levitation wrapper — Y-only so it doesn't fight the parent's entrance scale */}
+          <m.div
+            className="absolute inset-0"
+            {...(!reduce && entered ? {
+              animate: { y: [0, -8, 0] },
+              transition: { duration: 5, repeat: Infinity, ease: "easeInOut", delay: 1.3 },
+            } : {})}
+          >
+            <Image src="/portrait.webp" alt={siteConfig.name} fill sizes="52vw" className="object-cover object-top" priority loading="eager" />
+          </m.div>
           {/* Live variant 2 accepted: gradient drift — boundary slowly oscillates */}
           <div className="hero-gradient-drift absolute inset-0" />
           <div className="absolute bottom-0 left-0 right-0 h-48 bg-gradient-to-t from-[var(--color-surface-0)] to-transparent" />

--- a/components/sections/capability-matrix.tsx
+++ b/components/sections/capability-matrix.tsx
@@ -29,9 +29,10 @@ export function CapabilityMatrix() {
             key={c.area}
             initial={reduce ? false : { opacity: 0, y: 10 }}
             whileInView={reduce ? undefined : { opacity: 1, y: 0 }}
+            whileHover={reduce ? undefined : { x: 3, transition: { duration: 0.18, ease: EASE.out } }}
             viewport={{ once: true, margin: "-30px" }}
             transition={{ duration: DUR.reveal, delay: i * 0.05, ease: EASE.out }}
-            className="grid gap-3 py-7 sm:grid-cols-[1fr_2fr] sm:gap-8 lg:grid-cols-[220px_1fr_auto]"
+            className="grid gap-3 py-7 sm:grid-cols-[1fr_2fr] sm:gap-8 lg:grid-cols-[220px_1fr_auto] cursor-default"
           >
             {/* Area + level */}
             <div className="flex items-start gap-3">

--- a/components/sections/experience-timeline.tsx
+++ b/components/sections/experience-timeline.tsx
@@ -67,7 +67,7 @@ export function ExperienceTimeline() {
 
                 {/* Card */}
                 <m.div
-                  className="panel w-full rounded-lg transition-colors"
+                  className="panel card-shine card-glow w-full rounded-lg"
                   whileHover={reduce ? undefined : cardHover}
                 >
                   <button

--- a/components/sections/projects.tsx
+++ b/components/sections/projects.tsx
@@ -37,7 +37,7 @@ export function Projects() {
               <m.article
                 data-recruiter-highlight
                 whileHover={reduce ? undefined : cardHover}
-                className="panel grid gap-8 rounded-xl p-8 transition-colors hover:border-[var(--color-hairline-strong)] md:grid-cols-[1fr_2fr]"
+                className="panel card-shine card-glow grid gap-8 rounded-xl p-8 md:grid-cols-[1fr_2fr]"
               >
                 {/* Left: metric + title */}
                 <div className="flex flex-col justify-between gap-6">

--- a/components/sections/section.tsx
+++ b/components/sections/section.tsx
@@ -27,7 +27,7 @@ export function Section({
     >
       <div className="mx-auto max-w-5xl">
         <Reveal>
-          <h2 className="font-display max-w-3xl text-[clamp(1.875rem,4vw+0.5rem,3.75rem)] leading-[1.1] text-[var(--color-fg)] [text-wrap:balance]">
+          <h2 className="gradient-heading font-display max-w-3xl text-[clamp(1.875rem,4vw+0.5rem,3.75rem)] leading-[1.1] [text-wrap:balance]">
             {headline}
           </h2>
           {lead && (

--- a/lib/motion.ts
+++ b/lib/motion.ts
@@ -59,10 +59,11 @@ export const staggerContainer = {
   },
 } as const;
 
-/** Card hover — subtle lift + border brighten. Applied via whileHover. */
+/** Card hover — lift + scale + glow (pairs with .card-shine / .card-glow CSS). */
 export const cardHover = {
-  y: -2,
-  transition: { duration: DUR.micro, ease: EASE.out },
+  y: -5,
+  scale: 1.012,
+  transition: { duration: 0.25, ease: EASE.out },
 } as const;
 
 /** Button press feedback. Applied via whileTap. */


### PR DESCRIPTION
## Summary

Brings the portfolio's animation system in line with 2026 web design trends — tasteful and premium, not distracting. Every new animation respects `prefers-reduced-motion` and the `data-reduce-motion="1"` on-page toggle.

### What changed

**New CSS animation primitives (`app/globals.css`)**

| Primitive | What it does |
|---|---|
| `.gradient-heading` | Slow blue → cyan color sweep on all section `<h2>` titles (8s loop) |
| `.animate-levitate` | Sinusoidal 8px float — used on the hero portrait (5s loop) |
| `.card-shine` | Diagonal light sweep fires once on card hover/focus-within (lens flare effect) |
| `.card-glow` | Adds a blue edge glow + box-shadow depth on card hover (smooth 0.3s transition) |

**Motion system (`lib/motion.ts`)**
- `cardHover`: `y: -2` → `y: -5, scale: 1.012` — more dimensional lift on interactive cards

**Section headings (`components/sections/section.tsx`)**
- All `<h2>` section titles now use `.gradient-heading` for the animated color sweep

**Project, experience, case-study cards**
- Added `card-shine card-glow` CSS classes to all `panel`-based cards
- Removed the flat `transition-colors hover:border-[...]` fallback (card-glow replaces it with a more impactful blue edge glow)

**Capability matrix rows (`capability-matrix.tsx`)**
- Added `whileHover={{ x: 3 }}` nudge — rows now signal interactivity on hover

**Hero photo levitation (`identity-console.tsx`)**
- Added an inner `m.div` that animates `y: [0, -8, 0]` (5s, repeat infinite) with a 1.3s delay so levitation starts after the entrance scale completes — the two transforms live on different elements and never conflict

## Visual result
- Every section heading shimmers with a blue-cyan gradient wave
- Project and experience cards glow blue at the edges on hover, with a light sweep
- The hero portrait gently floats after the entrance animation completes
- Capability rows nudge right on hover, indicating clickability
- All motion disabled cleanly under reduced-motion preferences

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_