### PR TITLE
fix(a11y): use the accessible button fill for all white-text buttons

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -12,6 +12,12 @@ colors:
   ink-tertiary: "#788490"
   # Light ink-tertiary updated 2026-06-08: was #697785 (4.27:1 on surface-base-light — WCAG fail), now #616e7b (4.87:1 ✓)
   accent-blue: "#3b82f6"
+  # Solid-fill blue for white text. accent-blue is tuned for accent TEXT,
+  # borders and glows on dark surfaces; as a button fill under #ffffff it is
+  # only 3.68:1 — below WCAG AA. One token cannot serve both roles, so the
+  # fill has its own: #1d6edb on white = 4.88:1. Matches --color-button-primary
+  # in app/globals.css.
+  button-primary-fill: "#1d6edb"
   accent-cyan: "#22b8c4"
   accent-orange: "#f59e5b"
   accent-green: "#34d399"
@@ -75,12 +81,12 @@ spacing:
   3xl: "96px"
 components:
   button-primary:
-    backgroundColor: "{colors.accent-blue}"
+    backgroundColor: "{colors.button-primary-fill}"
     textColor: "#ffffff"
     rounded: "{rounded.md}"
     padding: "12px 24px"
   button-primary-hover:
-    backgroundColor: "{colors.accent-blue}"
+    backgroundColor: "{colors.button-primary-fill}"
     textColor: "#ffffff"
     rounded: "{rounded.md}"
     padding: "12px 24px"

--- a/app/globals.css
+++ b/app/globals.css
@@ -41,7 +41,7 @@
   /* Accents — used sparingly, only when meaningful. */
   --color-blue: #3b82f6;
   /* Button fill — slightly darker than brand blue for WCAG AA contrast with white text (4.5:1 min at 14px) */
-  --color-button-primary: #1d6edb; /* #1d6edb on white = 4.57:1 ✓ */
+  --color-button-primary: #1d6edb; /* #1d6edb on white = 4.88:1 ✓ AA */
   --color-cyan: #22b8c4;
   --color-orange: #f59e5b;
   --color-accent: var(--color-blue);

--- a/app/globals.css
+++ b/app/globals.css
@@ -65,6 +65,10 @@
   --ink-secondary: #97a1ad;
   --ink-tertiary: #788490;
   --accent-blue: #3b82f6;
+  /* Mirrors DESIGN.md colors.button-primary-fill. Same value as
+     --color-button-primary; this alias exists so the token checker can resolve
+     the spec, following the convention of the other aliases in this block. */
+  --button-primary-fill: #1d6edb;
   --accent-cyan: #22b8c4;
   --accent-orange: #f59e5b;
   --accent-green: #34d399;

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -27,7 +27,7 @@ export default function NotFound() {
         </p>
         <Link
           href="/"
-          className="mt-2 inline-flex items-center gap-2 rounded-lg bg-[var(--color-blue)] px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-blue)]"
+          className="mt-2 inline-flex items-center gap-2 rounded-lg bg-[var(--color-button-primary)] px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-blue)]"
         >
           ← Return home
         </Link>

--- a/components/recruiter-mode.tsx
+++ b/components/recruiter-mode.tsx
@@ -436,7 +436,7 @@ export function RecruiterMode() {
         transition={{ duration: 0.5, delay: 1.8, ease: [0.22, 1, 0.36, 1] }}
         className={`fixed bottom-5 left-5 z-floating flex items-center gap-2.5 rounded-full border px-4 py-2.5 text-sm font-medium shadow-2xl transition-all duration-300 ${
           recruiterOn
-            ? "border-[var(--color-blue)] bg-[var(--color-blue)] text-white shadow-[0_0_24px_-6px_var(--color-blue)]"
+            ? "border-[var(--color-blue)] bg-[var(--color-button-primary)] text-white shadow-[0_0_24px_-6px_var(--color-blue)]"
             : "border-[var(--color-blue)]/40 bg-[var(--color-surface-1)] text-[var(--color-fg)] hover:border-[var(--color-blue)] hover:shadow-[0_0_18px_-8px_var(--color-blue)]"
         }`}
       >
@@ -643,7 +643,7 @@ export function RecruiterMode() {
                             type="button"
                             aria-label={`Contact César about ${selectedRole.label} role`}
                             onClick={() => { setPanelOpen(false); setTimeout(() => document.dispatchEvent(new CustomEvent("open-contact-form")), 300); }}
-                            className="inline-flex items-center gap-2 rounded-md bg-[var(--color-blue)] px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-blue)]"
+                            className="inline-flex items-center gap-2 rounded-md bg-[var(--color-button-primary)] px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-blue)]"
                           >
                             {t.recruiterMode.ctaButton}
                           </button>
@@ -723,7 +723,7 @@ export function RecruiterMode() {
                         >
                           <div className={`max-w-[88%] rounded-xl px-4 py-3 text-sm leading-relaxed break-words ${
                             msg.role === "user"
-                              ? "bg-[var(--color-blue)] text-white"
+                              ? "bg-[var(--color-button-primary)] text-white"
                               : "panel-2 text-[var(--color-fg)]"
                           }`}>
                             {msg.role === "bot" && (
@@ -828,7 +828,7 @@ export function RecruiterMode() {
                       type="submit"
                       disabled={chatLoading || !chatInput.trim()}
                       aria-label="Send question"
-                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--color-blue)] text-sm font-medium text-white disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--color-blue)]"
+                      className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--color-button-primary)] text-sm font-medium text-white disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--color-blue)]"
                     >
                       ↑
                     </button>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -111,7 +111,7 @@ export function SiteHeader() {
       {/* Skip to main content — accessibility */}
       <a
         href="#top"
-        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-scanner focus:rounded focus:bg-[var(--color-blue)] focus:px-3 focus:py-2 focus:text-sm focus:text-white"
+        className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-scanner focus:rounded focus:bg-[var(--color-button-primary)] focus:px-3 focus:py-2 focus:text-sm focus:text-white"
       >
         Skip to content
       </a>


### PR DESCRIPTION
## Summary

The design-system check flags `button-primary` at **3.68:1** — white on `accent-blue` (`#3b82f6`), below WCAG AA's 4.5:1.

**The fix was already half-done.** `app/globals.css` defines `--color-button-primary` (`#1d6edb`, 4.88:1 with white) precisely for this, with a comment explaining why — and `contact-console`, `identity-console` and `case-study-body` already use it correctly.

Five other white-text fills were missed in that migration and still used `--color-blue`:

- `app/not-found.tsx` — the 404 CTA
- `components/recruiter-mode.tsx` ×3 — active tab, CTA, selected state, pager control
- `components/site-header.tsx` — the **skip link**, which is a keyboard-accessibility affordance, so poor contrast there is doubly unfortunate

So this isn't a design decision so much as finishing an incomplete migration to a token that already exists and already encodes the intended answer.

**Only fills under white text change.** Borders, focus rings and glows keep `accent-blue`, which is correctly tuned for accent text and edges on dark surfaces. One token can't serve both roles — that's the actual root cause, and `DESIGN.md` now says so.

### DESIGN.md

`button-primary` pointed at `{colors.accent-blue}`, so the spec itself encoded the failing combination and would re-flag on every run. It now has its own `button-primary-fill` token matching the CSS.

### One correction

The existing CSS comment recorded `#1d6edb` as **4.57:1**. It's actually **4.88:1**. The calculator used here reproduces the design bot's `3.68:1` for `#3b82f6` exactly, so the new figure is the trustworthy one. Both pass AA — the number was simply wrong, and it's now right in both `globals.css` and `DESIGN.md`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run build` — compiled successfully, 17/17 static pages generated
- [x] Verified `bg-[var(--color-button-primary)]` present in the built `_not-found.html`
- [x] Grep confirms **zero** remaining `bg-[var(--color-blue)]` + `text-white` combinations
- [x] Contrast recomputed: `#1d6edb` on white = 4.88:1 (AA ✓); token is defined in base `:root` and not overridden by the light theme, so it passes in both

## Out of scope

The bot's other warnings — missing `colors.primary`, and unmapped CSS variables like `--color-surface-*` — are pre-existing and unrelated to contrast. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved primary button styling with a WCAG-compliant blue background for white text.
  * Updated action buttons, links, chat controls, and skip-link focus states for more consistent contrast.
  * Corrected documented contrast ratio information for the primary button color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->