### PR TITLE
improve: cert hover lift, testimonial cinematic entrance, header a11y, contact row hover

### DIFF
--- a/components/sections/certifications.tsx
+++ b/components/sections/certifications.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { m, useReducedMotion } from "motion/react";
 import { Section } from "@/components/sections/section";
 import { Reveal } from "@/components/reveal";
 import { certifications } from "@/lib/site-config";
 import { useI18n } from "@/lib/i18n";
+import { EASE } from "@/lib/motion";
 
 // ─── Provider logos (accurate SVG reproductions of official brand marks) ───────
 
@@ -97,6 +99,7 @@ function providerAccent(group: string): { bg: string; border: string; check: str
 
 export function Certifications() {
   const { t } = useI18n();
+  const reduce = useReducedMotion();
 
   return (
     <Section
@@ -109,13 +112,14 @@ export function Certifications() {
           const accent = providerAccent(cat.group);
           return (
             <Reveal key={cat.group} delay={i * 0.08}>
-              <div
+              <m.div
                 data-recruiter-highlight
-                className="group relative flex h-full flex-col overflow-hidden rounded-xl border bg-[var(--color-surface-1)] transition-colors"
+                whileHover={reduce ? undefined : { y: -3, transition: { duration: 0.2, ease: EASE.out } }}
+                className="group relative flex h-full flex-col overflow-hidden rounded-xl border bg-[var(--color-surface-1)] transition-[border-color,box-shadow] hover:shadow-lg"
                 style={{ borderColor: accent.border }}
               >
                 {/* Top accent strip */}
-                <div className="h-[3px] w-full transition-opacity group-hover:opacity-70" style={{ backgroundColor: accent.bg }} />
+                <div className="h-[3px] w-full" style={{ backgroundColor: accent.bg }} />
 
                 <div className="flex flex-1 flex-col p-6">
                   {/* Provider logo + count */}
@@ -141,11 +145,13 @@ export function Certifications() {
                     {cat.items.map((it) => (
                       <li key={it.name} className="flex items-start gap-3">
                         <span
-                          className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white"
+                          className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-white"
                           style={{ backgroundColor: accent.bg }}
                           aria-hidden
                         >
-                          ✓
+                          <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                            <polyline points="2,6 5,9 10,3" />
+                          </svg>
                         </span>
                         <div className="flex-1 min-w-0">
                           <span className="text-[14px] leading-snug text-[var(--color-fg)]">{it.name}</span>
@@ -162,7 +168,7 @@ export function Certifications() {
                     ))}
                   </ul>
                 </div>
-              </div>
+              </m.div>
             </Reveal>
           );
         })}

--- a/components/sections/contact-console.tsx
+++ b/components/sections/contact-console.tsx
@@ -48,7 +48,7 @@ export function ContactConsole() {
             </div>
             <dl className="mt-6 divide-y divide-[var(--color-hairline)]">
               {rows.map((r) => (
-                <div key={r.k} className="flex items-center justify-between gap-4 py-3">
+                <div key={r.k} className="flex items-center justify-between gap-4 rounded-md py-3 px-2 -mx-2 transition-colors hover:bg-[var(--color-surface-2)]">
                   <dt className="font-mono text-xs uppercase tracking-wider text-[var(--color-fg-subtle)]">
                     {r.k}
                   </dt>
@@ -105,17 +105,19 @@ export function ContactConsole() {
                   href={siteConfig.links.linkedin}
                   target="_blank"
                   rel="noreferrer"
+                  aria-label="LinkedIn profile (opens in new tab)"
                   className="inline-flex items-center justify-center rounded-md border border-[var(--color-hairline-strong)] px-4 py-2.5 text-sm text-[var(--color-fg)] transition-colors hover:border-[var(--color-fg-muted)]"
                 >
-                  LinkedIn ↗
+                  LinkedIn <span aria-hidden> ↗</span>
                 </a>
                 <a
                   href={siteConfig.links.cv}
                   target="_blank"
                   rel="noreferrer"
+                  aria-label="Download CV (opens in new tab)"
                   className="inline-flex items-center justify-center rounded-md border border-[var(--color-hairline-strong)] px-4 py-2.5 text-sm text-[var(--color-fg)] transition-colors hover:border-[var(--color-fg-muted)]"
                 >
-                  {t.contact.downloadCv} ↓
+                  {t.contact.downloadCv} <span aria-hidden>↓</span>
                 </a>
               </div>
               <a

--- a/components/sections/testimonials.tsx
+++ b/components/sections/testimonials.tsx
@@ -20,8 +20,8 @@ export function Testimonials() {
         {testimonials.map((testimonial, i) => (
           <m.figure
             key={testimonial.name}
-            initial={reduce ? false : { opacity: 0, y: 12 }}
-            whileInView={reduce ? undefined : { opacity: 1, y: 0 }}
+            initial={reduce ? false : { opacity: 0, y: 24, filter: "blur(4px)" }}
+            whileInView={reduce ? undefined : { opacity: 1, y: 0, filter: "blur(0px)" }}
             viewport={{ once: true, margin: "-40px" }}
             transition={{ duration: DUR.reveal, delay: i * 0.1, ease: EASE.out }}
             className={`py-12 ${i % 2 === 1 ? "lg:pl-16 xl:pl-24" : ""}`}
@@ -30,7 +30,7 @@ export function Testimonials() {
             <blockquote className="relative">
               {/* Decorative opening mark */}
               <span
-                className="absolute -top-6 -left-2 font-display text-7xl leading-none text-[var(--color-blue)]/15 select-none"
+                className="absolute -top-6 -left-2 font-display text-7xl leading-none text-[var(--color-blue)]/25 select-none"
                 aria-hidden
               >
                 &ldquo;
@@ -44,14 +44,14 @@ export function Testimonials() {
             <figcaption className="mt-8 flex items-center gap-4">
               {/* Initials avatar */}
               <div
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--color-surface-2)] font-mono text-[13px] font-medium text-[var(--color-fg-muted)]"
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--color-surface-2)] font-display text-[13px] font-medium text-[var(--color-fg-muted)]"
                 aria-hidden
               >
                 {testimonial.name.split(" ").map(n => n[0]).join("").slice(0, 2)}
               </div>
               <div>
                 <p className="text-sm font-semibold text-[var(--color-fg)]">{testimonial.name}</p>
-                <p className="font-mono text-[11px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
+                <p className="font-mono text-[12px] uppercase tracking-wider text-[var(--color-fg-subtle)]">
                   {testimonial.title}
                 </p>
               </div>

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -132,6 +132,7 @@ export function SiteHeader() {
                 key={item.href}
                 href={`#${item.href}`}
                 onClick={(e) => { e.preventDefault(); document.dispatchEvent(new Event("close-assistant")); scrollToSection(item.href); }}
+                aria-current={active === item.href ? "true" : undefined}
                 className={`nav-hover-link font-ui text-[13px] font-medium tracking-wide ${
                   active === item.href
                     ? "active text-[var(--color-fg)]"
@@ -144,7 +145,7 @@ export function SiteHeader() {
           </nav>
           <div className="flex items-center gap-1.5">
             <span className="group hidden lg:flex items-center gap-1.5 rounded-full border border-[var(--color-ok)]/30 bg-[var(--color-ok)]/8 px-2.5 py-1 mr-1 transition-[border-color] duration-200 hover:border-[var(--color-ok)]/60">
-              <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-ok)] animate-pulse" aria-hidden />
+              <span className="status-dot shrink-0" aria-hidden />
               <span className="font-mono text-[10px] uppercase tracking-wider text-[var(--color-ok)]">{t.hero.available.split(" ")[0]}</span>
               <span className="overflow-hidden whitespace-nowrap font-mono text-[10px] uppercase tracking-wider text-[var(--color-ok)] max-w-0 group-hover:max-w-[9rem] transition-[max-width] duration-300 ease-out opacity-0 group-hover:opacity-100">
                 {t.hero.available.includes(" ") ? ` ${t.hero.available.slice(t.hero.available.indexOf(" ") + 1)}` : ""}
@@ -180,6 +181,8 @@ export function SiteHeader() {
         </div>
 
         <m.div
+          role="progressbar"
+          aria-label="Page reading progress"
           className="h-px origin-left bg-gradient-to-r from-[var(--color-blue)] via-[var(--color-cyan)] to-[var(--color-blue)]"
           style={{ scaleX, boxShadow: "0 0 6px 0 color-mix(in oklab, var(--color-blue) 55%, transparent)" }}
         />
@@ -215,9 +218,11 @@ export function SiteHeader() {
                 <button
                   onClick={() => setMobileOpen(false)}
                   aria-label="Close navigation"
-                  className="flex h-11 w-11 items-center justify-center text-lg leading-none text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]"
+                  className="flex h-11 w-11 items-center justify-center text-[var(--color-fg-subtle)] hover:text-[var(--color-fg)]"
                 >
-                  ✕
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden>
+                    <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
                 </button>
               </div>
               <nav aria-label="Mobile navigation" className="flex-1 overflow-y-auto p-4">


### PR DESCRIPTION
## Summary

- **Certifications**: Motion `whileHover` y:-3 lift + `hover:shadow-lg` on cards; fixed inverted accent strip hover (was dimming, now stays full opacity); replaced Unicode `✓` with an SVG checkmark for cross-platform consistency
- **Testimonials**: Stronger blur-in entrance — `y: 24` + `filter: blur(4px) → blur(0px)` for a cinematic 2026-style reveal; `font-display` initials avatar (warmer than mono); decorative quote mark opacity `/15 → /25`; attribution title bumped `11px → 12px` for legibility
- **Site header**: `aria-current="true"` on the active nav link; `role="progressbar" aria-label="..."` on the scroll progress bar; status-dot now uses the `.status-dot` CSS class with its `pulse-ring` halo animation instead of Tailwind's flat `animate-pulse`; mobile close button uses an SVG `×` instead of Unicode `✕`
- **Contact**: Decorative `↗` / `↓` arrows wrapped in `aria-hidden` spans; LinkedIn/CV links get descriptive `aria-label`; contact info rows gain a `hover:bg-[var(--color-surface-2)]` highlight for interactivity

## Test plan

- [ ] Certifications cards visually lift on hover; accent strip stays solid (not dimmer)
- [ ] Testimonial quotes animate in with blur on scroll
- [ ] Nav active link reports `aria-current` in DevTools
- [ ] Scroll progress bar has `role=progressbar` in DevTools
- [ ] Header status dot shows ripple-halo pulse (not flat Tailwind pulse)
- [ ] Mobile nav close button renders a crisp SVG ×
- [ ] Contact info rows highlight on hover; screen reader does not read `↗`/`↓`
- [ ] `npm run type-check` + `npm run lint` — both clean ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added subtle hover and entrance animations to certification cards and testimonials, with reduced-motion support.
  * Refined certification card shadows, borders, checkmarks, quote styling, avatars, and testimonial typography.
  * Improved contact link styling with clearer hover states and new-tab indicators.
  * Updated navigation and mobile menu visuals for improved clarity and accessibility.

* **Accessibility**
  * Added clearer active-navigation and reading-progress indicators.
  * Improved labels and accessible icons throughout the header and contact section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->