### PR TITLE
feat: green digital-decode hero portrait + /api/mcp agent server

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,241 @@
+export const runtime = "edge";
+export const dynamic = "force-dynamic";
+
+import { NextRequest, NextResponse } from "next/server";
+import { getIp, isRateLimited } from "@/lib/rate-limit";
+import { siteConfig, stats, experience, certifications, projects, capabilities } from "@/lib/site-config";
+
+/**
+ * MCP server for the portfolio — lets AI agents (Claude, ChatGPT, Kimi,
+ * Cursor, …) evaluate César for a role/engagement without a human clicking
+ * around the site. Stateless JSON-RPC 2.0 over a single POST endpoint: every
+ * call gets a synchronous `application/json` response, no SSE session to
+ * keep alive — the right shape for four read-mostly tools on a serverless
+ * edge function.
+ */
+
+const SERVER_INFO = { name: "cesarnogueira-portfolio", version: "1.0.0" };
+const PROTOCOL_VERSION = "2025-03-26";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type, mcp-protocol-version",
+};
+
+const TOOLS = [
+  {
+    name: "get_resume",
+    description:
+      "Get César Nogueira's structured resume: role, experience history, certifications, capabilities and key stats. Use this to evaluate his fit for a Cloud Architect, Platform Engineering or FinOps role or consulting engagement.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "list_case_studies",
+    description:
+      "List César's real client case studies (FinOps automation, big-data platforms, regulated banking/aviation cloud) with the problem, architecture, tech stack and a measurable outcome for each.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "check_availability",
+    description:
+      "Check César's current availability for new projects, his location/timezone and his typical response time.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "book_intro",
+    description:
+      "Send César a project introduction request on the caller's behalf. Requires a name, email and a short message describing the opportunity — delivered straight to his inbox.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Requester's full name" },
+        email: { type: "string", description: "Requester's email address, for César to reply to" },
+        message: { type: "string", description: "Short description of the role, project or opportunity" },
+      },
+      required: ["name", "email", "message"],
+      additionalProperties: false,
+    },
+  },
+] as const;
+
+type JsonRpcRequest = { jsonrpc?: string; id?: string | number | null; method?: string; params?: Record<string, unknown> };
+
+function textResult(text: string) {
+  return { content: [{ type: "text", text }] };
+}
+
+function rpcResult(id: unknown, result: unknown) {
+  return NextResponse.json({ jsonrpc: "2.0", id: id ?? null, result }, { headers: CORS_HEADERS });
+}
+
+function rpcError(id: unknown, code: number, message: string, status = 200) {
+  return NextResponse.json({ jsonrpc: "2.0", id: id ?? null, error: { code, message } }, { status, headers: CORS_HEADERS });
+}
+
+async function bookIntro(args: Record<string, unknown>, ip: string) {
+  if (isRateLimited(`${ip}:mcp:book_intro`, { windowMs: 60_000, max: 5 })) {
+    throw new Error("Too many requests — please try again in a minute.");
+  }
+
+  const name = String(args?.name ?? "").slice(0, 100).trim();
+  const email = String(args?.email ?? "").slice(0, 254).trim();
+  const message = String(args?.message ?? "").slice(0, 5000).trim();
+  if (!name || !email || !message) throw new Error("Missing required fields: name, email and message are all required.");
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error("Invalid email address.");
+
+  const key = process.env.RESEND_API_KEY;
+  if (!key) {
+    return textResult(
+      `Thanks ${name} — noted, but automated delivery isn't configured right now. Please reach César directly at ${siteConfig.links.email}.`,
+    );
+  }
+
+  const esc = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  const html = `<div style="font-family:monospace;background:#0a0a0a;color:#e0e0e0;padding:24px;">
+    <p style="color:#4ade80;font-size:11px;text-transform:uppercase;letter-spacing:0.1em;">MCP agent intro request</p>
+    <p><strong>From:</strong> ${esc(name)} (${esc(email)})</p>
+    <p style="white-space:pre-wrap;">${esc(message)}</p>
+  </div>`;
+
+  let r: Response;
+  try {
+    r = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      signal: AbortSignal.timeout(9000),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+      body: JSON.stringify({
+        from: "Portfolio MCP <portfolio@cesarnogueira.tech>",
+        to: siteConfig.links.email,
+        reply_to: email,
+        subject: `🤖 MCP intro request — from ${name}`,
+        html,
+      }),
+    });
+  } catch {
+    throw new Error("Delivery failed — please try again shortly.");
+  }
+  if (!r.ok) throw new Error("Delivery failed — please try again shortly.");
+
+  return textResult(`Sent. César replies within ${siteConfig.responseTime.toLowerCase().replace(/^usually /, "")} to ${email}.`);
+}
+
+async function callTool(name: string, args: Record<string, unknown>, ip: string) {
+  switch (name) {
+    case "get_resume": {
+      const payload = {
+        name: siteConfig.name,
+        role: siteConfig.role,
+        tagline: siteConfig.tagline,
+        location: siteConfig.location,
+        company: siteConfig.company,
+        stats: stats.map((s) => ({ label: s.label, value: `${"prefix" in s ? s.prefix : ""}${s.value}${s.suffix}` })),
+        experience: experience.map((e) => ({
+          company: e.company,
+          role: e.role,
+          period: e.period,
+          outcome: e.outcome,
+        })),
+        certifications: certifications.flatMap((c) => c.items.map((it) => it.name)),
+        capabilities: capabilities.map((c) => ({ area: c.area, level: c.level })),
+        cv: siteConfig.links.cv,
+        contact: siteConfig.links.email,
+      };
+      return textResult(JSON.stringify(payload, null, 2));
+    }
+    case "list_case_studies": {
+      const payload = projects.map((p) => ({
+        title: p.title,
+        client: p.client,
+        problem: p.problem,
+        architecture: p.architecture,
+        tech: p.tech,
+        outcome: p.outcome,
+        metric: `${p.metric} ${p.metricLabel}`,
+        url: `${siteConfig.url}/case-studies/${p.id}`,
+      }));
+      return textResult(JSON.stringify(payload, null, 2));
+    }
+    case "check_availability": {
+      const payload = {
+        availability: siteConfig.availability,
+        location: siteConfig.location,
+        responseTime: siteConfig.responseTime,
+        contact: siteConfig.links.email,
+      };
+      return textResult(JSON.stringify(payload, null, 2));
+    }
+    case "book_intro":
+      return bookIntro(args, ip);
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const ip = getIp(req);
+  if (isRateLimited(`${ip}:mcp`, { windowMs: 60_000, max: 40 })) {
+    return rpcError(null, -32000, "Rate limited", 429);
+  }
+
+  let body: JsonRpcRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return rpcError(null, -32700, "Parse error", 400);
+  }
+
+  const { id = null, method, params } = body ?? {};
+
+  switch (method) {
+    case "initialize":
+      return rpcResult(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      });
+
+    case "notifications/initialized":
+      return new NextResponse(null, { status: 202, headers: CORS_HEADERS });
+
+    case "tools/list":
+      return rpcResult(id, { tools: TOOLS });
+
+    case "tools/call": {
+      const toolName = String(params?.name ?? "");
+      const toolArgs = (params?.arguments as Record<string, unknown>) ?? {};
+      const tool = TOOLS.find((t) => t.name === toolName);
+      if (!tool) return rpcError(id, -32602, `Unknown tool: ${toolName}`);
+
+      try {
+        const result = await callTool(toolName, toolArgs, ip);
+        return rpcResult(id, result);
+      } catch (err) {
+        return rpcResult(id, {
+          content: [{ type: "text", text: err instanceof Error ? err.message : "Tool error" }],
+          isError: true,
+        });
+      }
+    }
+
+    default:
+      return rpcError(id, -32601, `Method not found: ${method}`, 404);
+  }
+}
+
+export async function GET() {
+  return NextResponse.json(
+    {
+      name: SERVER_INFO.name,
+      protocolVersion: PROTOCOL_VERSION,
+      transport: "streamable-http",
+      description: `MCP server for ${siteConfig.name} — ${siteConfig.shortRole}.`,
+      tools: TOOLS.map((t) => t.name),
+    },
+    { headers: CORS_HEADERS },
+  );
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS_HEADERS });
+}

--- a/components/hero/identity-console.tsx
+++ b/components/hero/identity-console.tsx
@@ -4,11 +4,11 @@ import { useEffect, useRef, useState } from "react";
 import { m, useMotionTemplate, useMotionValue, useReducedMotion } from "motion/react";
 import { siteConfig, stats, cvByLang } from "@/lib/site-config";
 import { useI18n } from "@/lib/i18n";
-import Image from "next/image";
 import { Counter } from "@/components/ui/counter";
 import { Magnetic } from "@/components/ui/magnetic";
 import { EASE, DUR, buttonPress } from "@/lib/motion";
 import { RecruiterScanner } from "@/components/recruiter-scanner";
+import { PortraitMatrix } from "@/components/ui/portrait-matrix";
 import { useTypewriter } from "@/hooks/use-typewriter";
 
 // Staggered hero entrance — each layer reveals 120ms after the previous
@@ -115,17 +115,7 @@ export function IdentityConsole() {
     >
       {/* Mobile: portrait as background, content on top */}
       <div className="absolute inset-0 -z-10 lg:hidden" aria-hidden>
-        <Image
-          src="/portrait-mobile.webp"
-          alt={siteConfig.name}
-          fill
-          sizes="100vw"
-          priority
-          loading="eager"
-          fetchPriority="high"
-          className="object-cover object-top"
-          style={{ opacity: 0.30 }}
-        />
+        <PortraitMatrix src="/portrait-mobile.webp" alt={siteConfig.name} className="h-full w-full" />
         <div className="absolute inset-0 bg-gradient-to-b from-[var(--color-surface-0)]/10 via-[var(--color-surface-0)]/60 to-[var(--color-surface-0)]" />
       </div>
 
@@ -280,7 +270,7 @@ export function IdentityConsole() {
               transition: { duration: 5, repeat: Infinity, ease: "easeInOut", delay: 1.3 },
             } : {})}
           >
-            <Image src="/portrait.webp" alt={siteConfig.name} fill sizes="52vw" className="object-cover object-top" priority loading="eager" />
+            <PortraitMatrix src="/portrait.webp" alt={siteConfig.name} className="h-full w-full" />
           </m.div>
           {/* Live variant 2 accepted: gradient drift — boundary slowly oscillates */}
           <div className="hero-gradient-drift absolute inset-0" />

--- a/components/ui/portrait-matrix.tsx
+++ b/components/ui/portrait-matrix.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useReducedMotion } from "motion/react";
+
+/**
+ * Renders a photo as a night-vision "digital decode" portrait — the subject
+ * rebuilt out of glowing green glyphs, à la a thermal/Matrix hybrid. Same
+ * glyph set as ui/matrix-rain.tsx (the recruiter-scanner backdrop) so the
+ * hero photo reads as part of the same hacker-console visual language rather
+ * than an unrelated effect.
+ *
+ * Technique: draw the source photo into a tiny offscreen canvas sized to the
+ * character grid (one drawImage call does the cover-fit crop + downsample —
+ * cheap, no per-pixel loops over the full-res image), read back per-cell
+ * luminance, then paint one glyph per cell on the visible canvas colored by
+ * a black → green → white ramp. A low-frequency loop rerolls a small
+ * percentage of cells each tick (patching only those cells, not a full
+ * redraw) for a subtle "decoding" flicker.
+ */
+
+const GLYPHS =
+  "アイウエオカキクケコサシスセソタチツテトナニヌネノ0123456789<>{}=+*#$%&/\\".split("");
+const CELL = 9; // px per character cell, CSS pixels
+
+function coverCrop(nw: number, nh: number, cw: number, ch: number) {
+  const s = Math.max(cw / nw, ch / nh);
+  const sw = Math.min(cw / s, nw);
+  const sh = Math.min(ch / s, nh);
+  return { sx: (nw - sw) / 2, sy: 0, sw, sh }; // object-position: top → sy fixed at 0
+}
+
+// Luminance (0-1) → rgba string: dark green → brand green → near-white hotspot.
+function glyphColor(l: number): string {
+  if (l < 0.34) {
+    const t = l / 0.34;
+    return `rgba(${Math.round(6 + t * 14)},${Math.round(60 + t * 90)},${Math.round(30 + t * 50)},${(0.35 + t * 0.35).toFixed(2)})`;
+  }
+  if (l < 0.7) {
+    const t = (l - 0.34) / 0.36;
+    return `rgba(${Math.round(20 + t * 50)},${Math.round(150 + t * 72)},${Math.round(80 + t * 40)},${(0.7 + t * 0.25).toFixed(2)})`;
+  }
+  const t = Math.min(1, (l - 0.7) / 0.3);
+  return `rgba(${Math.round(70 + t * 175)},${Math.round(222 + t * 33)},${Math.round(120 + t * 130)},${(0.95 + t * 0.05).toFixed(2)})`;
+}
+
+export function PortraitMatrix({
+  src,
+  alt,
+  className = "",
+}: {
+  src: string;
+  alt: string;
+  className?: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const reduce = useReducedMotion();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const canvas = canvasRef.current;
+    const img = imgRef.current;
+    if (!container || !canvas || !img) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const offscreen = document.createElement("canvas");
+    const octx = offscreen.getContext("2d", { willReadFrequently: true });
+    if (!octx) return;
+
+    let cols = 0;
+    let rows = 0;
+    let lum = new Float32Array(0);
+    let glyphIdx = new Uint8Array(0);
+    let raf = 0;
+    let last = 0;
+    let ready = false;
+
+    const rnd = (n: number) => (Math.random() * n) | 0;
+
+    const patch = (i: number) => {
+      const col = i % cols;
+      const row = (i / cols) | 0;
+      const x = col * CELL;
+      const y = row * CELL;
+      ctx.fillStyle = "#000";
+      ctx.fillRect(x, y, CELL, CELL);
+      const l = lum[i];
+      if (l < 0.045) return;
+      ctx.fillStyle = glyphColor(l);
+      ctx.fillText(GLYPHS[glyphIdx[i]], x, y);
+    };
+
+    const drawAll = () => {
+      const cw = container.clientWidth;
+      const ch = container.clientHeight;
+      ctx.fillStyle = "#000";
+      ctx.fillRect(0, 0, cw, ch);
+      for (let i = 0; i < cols * rows; i++) patch(i);
+    };
+
+    const sample = () => {
+      const cw = container.clientWidth;
+      const ch = container.clientHeight;
+      if (!cw || !ch || !img.naturalWidth) return;
+      cols = Math.max(1, Math.ceil(cw / CELL));
+      rows = Math.max(1, Math.ceil(ch / CELL));
+
+      const { sx, sy, sw, sh } = coverCrop(img.naturalWidth, img.naturalHeight, cw, ch);
+      offscreen.width = cols;
+      offscreen.height = rows;
+      octx.imageSmoothingEnabled = true;
+      octx.clearRect(0, 0, cols, rows);
+      octx.drawImage(img, sx, sy, sw, sh, 0, 0, cols, rows);
+      const data = octx.getImageData(0, 0, cols, rows).data;
+
+      lum = new Float32Array(cols * rows);
+      for (let i = 0; i < cols * rows; i++) {
+        const r = data[i * 4];
+        const g = data[i * 4 + 1];
+        const b = data[i * 4 + 2];
+        lum[i] = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+      }
+      glyphIdx = new Uint8Array(cols * rows);
+      for (let i = 0; i < glyphIdx.length; i++) glyphIdx[i] = rnd(GLYPHS.length);
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      canvas.width = Math.floor(cw * dpr);
+      canvas.height = Math.floor(ch * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.font = `${CELL + 2}px "Geist Mono", ui-monospace, monospace`;
+      ctx.textBaseline = "top";
+
+      ready = true;
+      drawAll();
+    };
+
+    const frame = (t: number) => {
+      if (ready && t - last > 110) {
+        last = t;
+        const flickerCount = Math.max(8, Math.floor(cols * rows * 0.02));
+        for (let n = 0; n < flickerCount; n++) {
+          const i = rnd(glyphIdx.length);
+          if (lum[i] >= 0.045) {
+            glyphIdx[i] = rnd(GLYPHS.length);
+            patch(i);
+          }
+        }
+      }
+      raf = requestAnimationFrame(frame);
+    };
+
+    const onLoad = () => {
+      sample();
+      if (!reduce) raf = requestAnimationFrame(frame);
+    };
+
+    if (img.complete && img.naturalWidth) onLoad();
+    else img.addEventListener("load", onLoad);
+
+    const ro = new ResizeObserver(() => sample());
+    ro.observe(container);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      img.removeEventListener("load", onLoad);
+      ro.disconnect();
+    };
+  }, [reduce, src]);
+
+  return (
+    <div ref={containerRef} className={`relative overflow-hidden bg-black ${className}`}>
+      <img
+        ref={imgRef}
+        src={src}
+        alt=""
+        aria-hidden
+        className="sr-only"
+        decoding="async"
+        loading="eager"
+        fetchPriority="high"
+      />
+      <canvas ref={canvasRef} role="img" aria-label={alt} className="absolute inset-0 h-full w-full" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

**Hero portrait → Matrix digital-decode effect**
- New `components/ui/portrait-matrix.tsx`: samples the portrait photo into a character grid with one cover-fit `drawImage` call (fast — no per-pixel loop over the full-res image), then paints each cell as a glyph on a black → green → white luminance ramp
- Reuses the same glyph set as the existing recruiter-scanner Matrix rain, so the hero photo now reads as part of that hacker-console visual language rather than an unrelated effect
- A low-frequency loop patches ~2% of cells per tick (not a full redraw) for a subtle "decode" flicker; `prefers-reduced-motion` renders one static frame, no animation
- Replaces the plain `next/image` portrait on both the desktop hero column and the mobile background layer

**`/api/mcp` — MCP server for AI agents**
- Stateless JSON-RPC 2.0 endpoint (streamable-http transport, synchronous `application/json` responses — no SSE session to manage on a serverless edge function)
- Four tools: `get_resume`, `list_case_studies`, `check_availability`, `book_intro` — lets Claude, ChatGPT, Kimi, Cursor or any MCP client evaluate César and send an intro request without a human browsing the site
- `book_intro` reuses the Resend pattern from `/api/contact`, degrading gracefully to a direct-email pointer when `RESEND_API_KEY` isn't set
- Rate-limited with namespaced store keys (`${ip}:mcp`, `${ip}:mcp:book_intro}`) — caught and fixed a real bug during testing where the endpoint-wide throttle and the stricter per-tool throttle shared the same counter key and silently exhausted each other's budget

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds; `/api/mcp` registers as a dynamic edge route
- [x] Verified visually with Playwright screenshots — hero portrait renders as a legible green glyph portrait on desktop and mobile
- [x] Curl-tested `/api/mcp`: `initialize`, `tools/list`, `tools/call` for all four tools, invalid-email rejection, unknown-tool error, `GET` discovery response
- [ ] Confirm `RESEND_API_KEY` is set in Vercel prod so `book_intro` actually delivers (falls back to a direct-email message otherwise — no crash either way)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an MCP server endpoint with tools for viewing resume details, case studies, availability, introductions, and booking requests.
  - Added validation, rate limiting, structured error responses, and optional email delivery for introduction requests.
  - Added a dynamic glyph-based portrait effect for hero images, with responsive rendering and reduced-motion support.
- **Accessibility**
  - Portrait visuals include accessible labels and adapt to reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->