### PR TITLE
feat: cursor parallax on hero portrait, livelier decode flicker

### DIFF
--- a/components/hero/identity-console.tsx
+++ b/components/hero/identity-console.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { m, useMotionTemplate, useMotionValue, useReducedMotion } from "motion/react";
+import { m, useMotionTemplate, useMotionValue, useReducedMotion, useSpring, useTransform } from "motion/react";
 import { siteConfig, stats, cvByLang } from "@/lib/site-config";
 import { useI18n } from "@/lib/i18n";
 import { Counter } from "@/components/ui/counter";
@@ -25,6 +25,17 @@ export function IdentityConsole() {
   const mouseX = useMotionValue(-1000);
   const mouseY = useMotionValue(-1000);
   const spotlight = useMotionTemplate`radial-gradient(520px at ${mouseX}px ${mouseY}px, color-mix(in oklab, var(--color-blue) 5%, transparent) 0%, transparent 70%)`;
+
+  // Portrait parallax — cursor position within the hero (normalized -0.5..0.5)
+  // drives a small spring-smoothed tilt/shift on the photo, so it reads as a
+  // physical layer with depth rather than a flat, static image.
+  const parallaxX = useMotionValue(0);
+  const parallaxY = useMotionValue(0);
+  const parallaxSpringX = useSpring(parallaxX, { stiffness: 120, damping: 18, mass: 0.6 });
+  const parallaxSpringY = useSpring(parallaxY, { stiffness: 120, damping: 18, mass: 0.6 });
+  const photoShiftX = useTransform(parallaxSpringX, [-0.5, 0.5], [-14, 14]);
+  const photoRotateY = useTransform(parallaxSpringX, [-0.5, 0.5], [-4, 4]);
+  const photoRotateX = useTransform(parallaxSpringY, [-0.5, 0.5], [4, -4]);
 
   // Continuous-handoff fix: this section mounts at the same time as the
   // pinned IntroSequence sitting above it, so a mount-triggered entrance
@@ -107,10 +118,14 @@ export function IdentityConsole() {
         const rect = e.currentTarget.getBoundingClientRect();
         mouseX.set(e.clientX - rect.left);
         mouseY.set(e.clientY - rect.top);
+        parallaxX.set((e.clientX - rect.left) / rect.width - 0.5);
+        parallaxY.set((e.clientY - rect.top) / rect.height - 0.5);
       }}
       onMouseLeave={reduce ? undefined : () => {
         mouseX.set(-1000);
         mouseY.set(-1000);
+        parallaxX.set(0);
+        parallaxY.set(0);
       }}
     >
       {/* Mobile: portrait as background, content on top */}
@@ -256,15 +271,19 @@ export function IdentityConsole() {
         <m.div
           className="relative hidden lg:block"
           aria-hidden
+          style={{ perspective: 1200 }}
           {...(reduce ? {} : {
             initial: { opacity: 0, scale: 1.03 },
             animate: entered ? { opacity: 1, scale: 1 } : { opacity: 0, scale: 1.03 },
             transition: { duration: 1.1, delay: DELAYS.photo, ease: EASE.out },
           })}
         >
-          {/* Levitation wrapper — Y-only so it doesn't fight the parent's entrance scale */}
+          {/* Levitation + parallax wrapper — continuous Y float (animate) composes with
+              cursor-driven x/rotateX/rotateY (style, spring-smoothed motion values) on the
+              same element; Motion merges both into one transform, so they don't fight. */}
           <m.div
             className="absolute inset-0"
+            style={!reduce ? { x: photoShiftX, rotateX: photoRotateX, rotateY: photoRotateY } : undefined}
             {...(!reduce && entered ? {
               animate: { y: [0, -8, 0] },
               transition: { duration: 5, repeat: Infinity, ease: "easeInOut", delay: 1.3 },

--- a/components/ui/portrait-matrix.tsx
+++ b/components/ui/portrait-matrix.tsx
@@ -162,9 +162,9 @@ export function PortraitMatrix({
     };
 
     const frame = (t: number) => {
-      if (ready && t - last > 110) {
+      if (ready && t - last > 80) {
         last = t;
-        const flickerCount = Math.max(8, Math.floor(cols * rows * 0.02));
+        const flickerCount = Math.max(10, Math.floor(cols * rows * 0.03));
         for (let n = 0; n < flickerCount; n++) {
           const i = rnd(glyphIdx.length);
           if (lum[i] >= 0.045) {


### PR DESCRIPTION
## Summary

- **Cursor parallax on the hero portrait**: the digital-decode photo now tilts and shifts a few pixels toward the cursor (spring-smoothed `rotateX`/`rotateY`/`x`, driven by normalized mouse position within the hero section), giving it a sense of physical depth instead of sitting flat. Composed on the same wrapper that already handles the idle levitation float — Motion merges both transforms without conflict. Disabled under `prefers-reduced-motion`, consistent with the rest of the hero.
- **Livelier ambient decode flicker**: tick interval `110ms → 80ms`, reroll percentage `2% → 3%`, so the glyph grid feels more alive at rest, not just on hover.

## Test plan

- [ ] Moving the cursor around the hero (desktop, ≥1024px) tilts/shifts the portrait smoothly toward the pointer, and eases back to center on mouse-leave
- [ ] Portrait still composes correctly with the existing idle float (no jitter/fighting between the two transforms)
- [ ] With "Reduce motion" enabled (site toggle or OS setting), the portrait stays static — no tilt, no float
- [ ] Ambient flicker reads as slightly livelier without being distracting
- [ ] `npm run type-check` + `npm run lint` — both clean ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added interactive portrait parallax that responds smoothly to cursor movement on desktop.
  * Preserved existing portrait animations while respecting reduced-motion preferences.
  * Increased the portrait matrix flicker activity for a more dynamic visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->