### PR TITLE
feat: fade floating buttons near footer, shorten recruiter button label

### DIFF
--- a/components/chatbot/assistant.tsx
+++ b/components/chatbot/assistant.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { faq } from "@/lib/site-config";
 import { useI18n } from "@/lib/i18n";
 import { EASE, DUR } from "@/lib/motion";
+import { useFooterVisible } from "@/hooks/use-footer-visible";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -61,6 +62,16 @@ export function Assistant() {
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const footerVisible = useFooterVisible();
+  // Gates the footer-visibility fade behind the one-time entrance delay below —
+  // without this, every re-show after scrolling away from the footer would
+  // replay the initial "arrival" delay instead of fading back in immediately.
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setEntered(true), reduce ? 0 : 500);
+    return () => clearTimeout(timer);
+  }, [reduce]);
 
   const listRef = useRef<HTMLDivElement>(null);
   const lastAnswerRef = useRef<HTMLDivElement>(null);
@@ -210,8 +221,17 @@ export function Assistant() {
         aria-expanded={open}
         onClick={() => setOpen((o) => !o)}
         initial={reduce ? false : { opacity: 0, y: 14 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: DUR.reveal, delay: 0.5, ease: EASE.spring }}
+        animate={
+          !entered
+            ? undefined
+            : footerVisible
+              ? { opacity: 0, y: reduce ? 0 : 10 }
+              : { opacity: 1, y: 0 }
+        }
+        transition={{ duration: DUR.reveal, ease: EASE.spring }}
+        style={{ pointerEvents: entered && footerVisible ? "none" : "auto" }}
+        aria-hidden={footerVisible}
+        tabIndex={footerVisible ? -1 : 0}
         whileHover={reduce ? undefined : { scale: 1.04, transition: { duration: DUR.micro } }}
         whileTap={reduce ? undefined : { scale: 0.95, transition: { duration: DUR.micro } }}
         className="fixed bottom-[calc(1.25rem+env(safe-area-inset-bottom,0px))] right-5 z-floating flex items-center gap-2 rounded-full border border-[var(--color-hairline-strong)] bg-[var(--color-surface-1)] px-4 py-3 text-sm text-[var(--color-fg)] shadow-2xl transition-colors hover:border-[var(--color-blue)]"

--- a/components/recruiter-mode.tsx
+++ b/components/recruiter-mode.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, m, useReducedMotion } from "motion/react";
 import { useI18n } from "@/lib/i18n";
 import { siteConfig } from "@/lib/site-config";
+import { useFooterVisible } from "@/hooks/use-footer-visible";
 
 // ─── Role profiles ────────────────────────────────────────────────────────────
 
@@ -265,6 +266,16 @@ export function RecruiterMode() {
 
   const reduce = useReducedMotion();
   const { t, lang } = useI18n();
+  const footerVisible = useFooterVisible();
+
+  // Gates the footer-visibility fade behind the one-time entrance delay below —
+  // without this, every re-show after scrolling away from the footer would
+  // replay the initial 1.8s "arrival" delay instead of fading back in immediately.
+  const [entered, setEntered] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setEntered(true), reduce ? 0 : 1800);
+    return () => clearTimeout(timer);
+  }, [reduce]);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
@@ -432,8 +443,17 @@ export function RecruiterMode() {
         aria-expanded={panelOpen}
         aria-controls={PANEL_ID}
         initial={reduce ? false : { opacity: 0, x: -20 }}
-        animate={{ opacity: 1, x: 0 }}
-        transition={{ duration: 0.5, delay: 1.8, ease: [0.22, 1, 0.36, 1] }}
+        animate={
+          !entered
+            ? undefined
+            : footerVisible
+              ? { opacity: 0, x: reduce ? 0 : -12 }
+              : { opacity: 1, x: 0 }
+        }
+        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        style={{ pointerEvents: entered && footerVisible ? "none" : "auto" }}
+        aria-hidden={footerVisible}
+        tabIndex={footerVisible ? -1 : 0}
         className={`fixed bottom-5 left-5 z-floating flex items-center gap-2.5 rounded-full border px-4 py-2.5 text-sm font-medium shadow-2xl transition-all duration-300 ${
           recruiterOn
             ? "border-[var(--color-blue)] bg-[var(--color-button-primary)] text-white shadow-[0_0_24px_-6px_var(--color-blue)]"

--- a/hooks/use-footer-visible.ts
+++ b/hooks/use-footer-visible.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * True once the page's <footer> enters the viewport — used to fade out
+ * floating widgets (recruiter assistant, chat launcher) so they don't
+ * overlap the footer's own links/icons.
+ */
+export function useFooterVisible() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const footer = document.querySelector("footer");
+    if (!footer) return;
+    const io = new IntersectionObserver(([entry]) => setVisible(entry.isIntersecting), {
+      threshold: 0,
+    });
+    io.observe(footer);
+    return () => io.disconnect();
+  }, []);
+
+  return visible;
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -683,7 +683,7 @@ const en: Dict = {
     quickImpact: "Impact",
     quickCredentials: "Credentials",
     quickCareer: "Career",
-    hiringAssistant: "Hiring Assistant",
+    hiringAssistant: "Recruiters",
     tabRoleFit: "Role Fit",
     tabAIChat: "AI Chat",
     roleStrengths: {
@@ -1139,7 +1139,7 @@ const pt: Dict = {
     quickImpact: "Impacto",
     quickCredentials: "Credenciais",
     quickCareer: "Carreira",
-    hiringAssistant: "Assistente de Recrutamento",
+    hiringAssistant: "Recrutadores",
     tabRoleFit: "Fit do Cargo",
     tabAIChat: "Chat IA",
     roleStrengths: {
@@ -1595,7 +1595,7 @@ const es: Dict = {
     quickImpact: "Impacto",
     quickCredentials: "Credenciales",
     quickCareer: "Carrera",
-    hiringAssistant: "Asistente de Contratación",
+    hiringAssistant: "Reclutadores",
     tabRoleFit: "Ajuste al Rol",
     tabAIChat: "Chat IA",
     roleStrengths: {
@@ -2051,7 +2051,7 @@ const fr: Dict = {
     quickImpact: "Impact",
     quickCredentials: "Références",
     quickCareer: "Carrière",
-    hiringAssistant: "Assistant Recrutement",
+    hiringAssistant: "Recruteurs",
     tabRoleFit: "Adéquation Poste",
     tabAIChat: "Chat IA",
     roleStrengths: {
@@ -2507,7 +2507,7 @@ const zh: Dict = {
     quickImpact: "业务影响",
     quickCredentials: "资质证书",
     quickCareer: "职业历程",
-    hiringAssistant: "招聘助手",
+    hiringAssistant: "招聘",
     tabRoleFit: "岗位匹配",
     tabAIChat: "AI 对话",
     roleStrengths: {


### PR DESCRIPTION
## Summary

- **Footer-aware fade for floating widgets**: the recruiter assistant button (bottom-left) and the chat launcher button (bottom-right) now fade out — opacity, `pointer-events: none`, `aria-hidden` — once the footer scrolls into view, so they stop overlapping its links/icons. They fade back in as soon as the footer scrolls back out of view. New `hooks/use-footer-visible.ts` (a small `IntersectionObserver` on `<footer>`) drives both.
- **Shortened recruiter button label**: `hiringAssistant` in `lib/i18n.tsx` is now a shorter word across all 5 locales — EN "Hiring Assistant" → "Recruiters", PT "Assistente de Recrutamento" → "Recrutadores", ES → "Reclutadores", FR → "Recruteurs", ZH → "招聘". Since the panel title reuses the same string, it's shorter there too.

## Test plan

- [ ] Scrolling to the footer fades out both floating buttons smoothly; scrolling back up fades them back in
- [ ] Neither button is focusable/clickable while faded out (tab order skips them at the footer)
- [ ] The one-time entrance delay (staggered arrival on page load) doesn't replay every time you scroll away from the footer and back
- [ ] Recruiter button now reads "Recruiters" (EN) / "Recrutadores" (PT) instead of the longer original label
- [ ] `npm run type-check` + `npm run lint` — both clean ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_