### PR TITLE
feat: slide chat launcher clear of the recruiter panel when it opens

### DIFF
--- a/components/chatbot/assistant.tsx
+++ b/components/chatbot/assistant.tsx
@@ -68,6 +68,18 @@ export function Assistant() {
   // without this, every re-show after scrolling away from the footer would
   // replay the initial "arrival" delay instead of fading back in immediately.
   const [entered, setEntered] = useState(false);
+
+  // The recruiter side panel (~440-460px wide, right-anchored) sits above this
+  // launcher's default position — slide it clear of the panel instead of
+  // letting the two overlap.
+  const [recruiterPanelOpen, setRecruiterPanelOpen] = useState(false);
+  useEffect(() => {
+    const onToggle = (e: Event) => {
+      setRecruiterPanelOpen((e as CustomEvent<{ open: boolean }>).detail.open);
+    };
+    document.addEventListener("recruiter-panel-toggle", onToggle);
+    return () => document.removeEventListener("recruiter-panel-toggle", onToggle);
+  }, []);
   useEffect(() => {
     const timer = setTimeout(() => setEntered(true), reduce ? 0 : 500);
     return () => clearTimeout(timer);
@@ -225,10 +237,14 @@ export function Assistant() {
           !entered
             ? undefined
             : footerVisible
-              ? { opacity: 0, y: reduce ? 0 : 10 }
-              : { opacity: 1, y: 0 }
+              ? { opacity: 0, y: reduce ? 0 : 10, x: 0 }
+              // Slide clear of the recruiter side panel (~460px wide, right-anchored)
+              // instead of sitting on top of it. The shift is applied regardless of
+              // `reduce` — it's a functional repositioning, not decorative motion —
+              // only its duration collapses to an instant snap.
+              : { opacity: 1, y: 0, x: recruiterPanelOpen ? -488 : 0 }
         }
-        transition={{ duration: DUR.reveal, ease: EASE.spring }}
+        transition={{ duration: reduce ? 0 : DUR.reveal, ease: EASE.spring }}
         style={{ pointerEvents: entered && footerVisible ? "none" : "auto" }}
         aria-hidden={footerVisible}
         tabIndex={footerVisible ? -1 : 0}

--- a/components/recruiter-mode.tsx
+++ b/components/recruiter-mode.tsx
@@ -307,6 +307,12 @@ export function RecruiterMode() {
     }
   }, [panelOpen]);
 
+  // Tell other floating widgets (chat launcher) this panel is covering the
+  // right edge of the screen, so they can get out of its way.
+  useEffect(() => {
+    document.dispatchEvent(new CustomEvent("recruiter-panel-toggle", { detail: { open: panelOpen } }));
+  }, [panelOpen]);
+
   // Focus input when switching to chat tab
   useEffect(() => {
     if (tab === "chat" && panelOpen) {


### PR DESCRIPTION
## Summary

- The "Ask about César" chat launcher (bottom-right) was sitting on top of the recruiter side panel (~440-460px wide, right-anchored) whenever the panel was open.
- `recruiter-mode.tsx` now dispatches a `recruiter-panel-toggle` custom event on open/close; `chatbot/assistant.tsx` listens and slides the launcher `-488px` left while the panel is open, clearing it.
- The shift is applied regardless of `prefers-reduced-motion` (it's a functional repositioning, not decorative motion) — only the transition duration collapses to an instant snap in that case.

## Test plan

- [ ] Opening the recruiter panel slides the chat launcher left, clear of the panel's edge
- [ ] Closing the panel slides the launcher back to its original position
- [ ] Chat launcher remains clickable in its shifted position
- [ ] With "Reduce motion" enabled, the launcher still repositions correctly, just without the animated slide
- [ ] `npm run type-check` + `npm run lint` — both clean ✓

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRYEXiXt1EwyiPgGe9HNQD)_