### PR TITLE
fix(seo): list /connect in sitemap.xml

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -17,6 +17,7 @@ function selfLanguages(url: string) {
 // wasting Google's crawl budget signalling "new" on every deployment.
 const HOME_MODIFIED = new Date("2026-07-21");
 const CASE_STUDIES_MODIFIED = new Date("2026-07-21");
+const CONNECT_MODIFIED = new Date("2026-08-12");
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = siteConfig.url;
@@ -35,6 +36,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.8,
       alternates: { languages: selfLanguages(`${base}/case-studies`) },
+    },
+    {
+      url: `${base}/connect`,
+      lastModified: CONNECT_MODIFIED,
+      changeFrequency: "monthly",
+      priority: 0.6,
+      alternates: { languages: selfLanguages(`${base}/connect`) },
     },
     ...projects.map((p) => {
       const url = `${base}/case-studies/${p.id}`;


### PR DESCRIPTION
## Summary

Weekly SEO check found one concrete gap: **`/connect` is a live, indexable page that was missing from `sitemap.xml`.**

The MCP connector page shipped on 2026-08-12 (`381c0e8`), but `app/sitemap.ts` had not been touched since 2026-08-09 (`781406f`) — so the route was never added. Everything else about the page is already set up for indexing:

- serves HTTP 200 in production
- `robots: index, follow`
- self-referencing canonical (`https://cesarnogueira.tech/connect`)
- OG + Twitter card metadata
- `WebPage` + `BreadcrumbList` JSON-LD

That combination makes the sitemap omission an oversight rather than a deliberate exclusion, so this adds the entry.

The new entry follows the existing per-entry pattern: `selfLanguages()` receives the page's **own** URL, so its `en`/`x-default` alternates self-reference rather than pointing at the homepage. Priority `0.6` places it below the case-studies index (`0.8`) and the individual case studies (`0.7`).

## Test plan

- `npm run type-check` — pass
- `npm run lint` — pass
- `npm run build` — pass
- Inspected the prerendered `.next/server/app/sitemap.xml.body`: 6 entries, `/connect` present, and **every** entry's `hreflang` alternates verified to self-reference its own `<loc>` (guards the previously-fixed hardcoded-homepage-alternate bug against regression).

## Also checked, no change needed

- All production URLs (home, `/case-studies`, 3 case-study slugs, `/connect`, `/robots.txt`, `/sitemap.xml`) return 200.
- Titles and descriptions measured at decoded length — all within the SERP windows except two marginal cases left deliberately untouched (see below).
- JSON-LD `@graph` on the homepage parses cleanly: `Person` + `WebSite` + `ProfessionalService`, with `sameAs` cross-links to up2cloud.tech intact.
- Every rendered `<img>` has an `alt` attribute; exactly one `<h1>` per page.

## Noted, not changed

- Homepage `<title>` is 62 chars (2 over the 60 target) and `/connect`'s description is 159 (1 over 158). Both are close enough that rewriting them would reset SERP snippets for no measurable gain.
- `/_not-found` carries `index, follow` and canonicalises to the homepage. In practice the host serves it with a real HTTP 404, which is the authoritative signal to crawlers, so this is cosmetic — but worth a decision if the 404 handling ever changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5gWqGzhPq1dnwKZcHxGKU)_